### PR TITLE
Write log

### DIFF
--- a/Utils/Utils_v1d0.py
+++ b/Utils/Utils_v1d0.py
@@ -590,8 +590,6 @@ class RenormaliseMatricesForScaledNoise(object):
 ## ======================================================================================================
 
 def write_log_file(array_save_directory, file_root, args):
-	import subprocess
-	
 	# make log file directory if it doesn't exist
 	log_dir = 'log_files/'
 	if not os.path.exists(log_dir):

--- a/__init__.py
+++ b/__init__.py
@@ -52,6 +52,7 @@ from likelihood_tests.SimpleEoRtestWQ.Likelihood_v1d763_3D_ZM_standalone_GPU_v2d
 from Utils import PriorC, ParseCommandLineArguments, DataUnitConversionmkandJyperpix, WriteDataToFits
 from Utils import ExtractDataFrom21cmFASTCube, plot_signal_vs_MLsignal_residuals
 from Utils import generate_output_file_base, RenormaliseMatricesForScaledNoise
+from Utils import write_log_file
 
 from Utils import remove_unused_header_variables, construct_aplpy_image_from_fits
 

--- a/run_EoR.py
+++ b/run_EoR.py
@@ -8,7 +8,6 @@ import sys
 head,tail = os.path.split(os.path.split(os.getcwd())[0])
 sys.path.append(head)
 from BayesEoR import * #Make everything available for now, this can be refined later
-from BayesEoR.Utils.Utils_v1d0 import write_log_file
 import BayesEoR.Params.params as p
 
 mpi_rank = 0


### PR DESCRIPTION
Added a function in Utils that writes a log file using the output file root for MultiNest with the extension `.log`.  The driver script imports this function at the beginning of the script and calls it whenever an actual analysis with MultiNest/PolyChord is being run.