### PR TITLE
Command line args

### DIFF
--- a/Params/params.py
+++ b/Params/params.py
@@ -33,7 +33,7 @@ EoR_npz_path = '/users/psims/EoR/EoR_simulations/21cmFAST_512MPc_512pix_128pix/F
 box_size_21cmFAST_pix = 128 #Must match EoR_npz_path parameters
 box_size_21cmFAST_Mpc = 512 #Must match EoR_npz_path parameters
 
-EoR_npz_path_sc = '/users/jburba/data/shared/PSims/BayesEoR_files_P/EoRsims/Hoag19/21cm_mK_z7.600_nf0.883_useTs0.0_aveTb21.06_cube_side_pix512_cube_side_Mpc2048.npz'
+EoR_npz_path_sc = '/users/psims/EoR/EoR_simulations/21cmFAST_2048MPc_2048pix_512pix_AstroParamExploration1/Fits/npzs/Zeta10.0_Tvir1.0e+05_mfp22.2_Taue0.041_zre-1.000_delz-1.000_512_2048Mpc/21cm_mK_z7.600_nf0.883_useTs0.0_aveTb21.06_cube_side_pix512_cube_side_Mpc2048.npz'
 box_size_21cmFAST_pix_sc = 512 #Must match EoR_npz_path parameters
 box_size_21cmFAST_Mpc_sc = 2048 #Must match EoR_npz_path parameters
 
@@ -180,7 +180,7 @@ inverse_LW_power = 1.e-16 #Include minimal prior over LW modes to ensure numeric
 ###
 # NUDFT params
 ###
-instrument_model_directory = '/users/jburba/data/jburba/bayes/BayesEoR/Instrument_Model/HERA_331_baselines_shorter_than_29d3_for_30_0d5_min_time_steps/'
+instrument_model_directory = '/users/psims/EoR/Python_Scripts/BayesEoR/git_version/BayesEoR/Instrument_Model/HERA_331_baselines_shorter_than_29d3_for_30_0d5_min_time_steps/'
 uv_pixel_width_wavelengths = 2.5 #Define a fixed pixel width in wavelengths
 
 


### PR DESCRIPTION
On the plots, `CL` refers to the `command_line_args` branch and `master` refers to the `master` branch.  The plots below show that the beams agree when using the command line arguments for beam type, reference frequency, fwhm, etc. instead of the hard-coded parameter values in `Params/params.py`.  The power spectra for each case can also be seen to agree.  So, it doesn't look like any of the changes I made by incorporating the command line arguments has any effect on the analysis.

**Uniform beam, amplitude 1.0 comparison**:
![uniform_beam_comparison](https://user-images.githubusercontent.com/15479617/59876850-9e209100-9372-11e9-8f98-d5a65ddfd27c.png)
![ps_uniform_beam_comparison](https://user-images.githubusercontent.com/15479617/59876849-9e209100-9372-11e9-9da6-73d99b4f2867.png)

**Gaussian beam, amplitude 1.0, varying FWHM comparison**:
![gaussian_beam_fwhm_5d0_deg_comparison](https://user-images.githubusercontent.com/15479617/59876845-9e209100-9372-11e9-8da9-8baa158e9689.png)
![gaussian_beam_fwhm_9d0_deg_comparison](https://user-images.githubusercontent.com/15479617/59876846-9e209100-9372-11e9-963c-f1352b1c9cbd.png)
![gaussian_beam_fwhm_15d0_deg_comparison](https://user-images.githubusercontent.com/15479617/59876847-9e209100-9372-11e9-9f26-99c4ce2bff47.png)
![ps_gaussian_beam_comparison](https://user-images.githubusercontent.com/15479617/59876848-9e209100-9372-11e9-8f01-4506d69edb41.png)