### PR TITLE
Log writing

### DIFF
--- a/Utils/Utils_v1d0.py
+++ b/Utils/Utils_v1d0.py
@@ -614,14 +614,36 @@ def load_baseline_redundancy_array(instrument_model_directory):
 ## ======================================================================================================
 ## ======================================================================================================
 
+def write_log_file(array_save_directory, file_root):
+	# make log file directory if it doesn't exist
+	log_dir = os.path.join(os.getcwd(), 'log_files/')
+	if not os.path.exists(log_dir):
+		print('Creating log directory at {}'.format(log_dir))
+		os.mkdir(log_dir)
 
+	# Get git version and hash info
+	version_info = {}
+	version_info['git_origin'] = subprocess.check_output(['git', 'config', '--get', 'remote.origin.url'], stderr=subprocess.STDOUT)
+	version_info['git_hash'] = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.STDOUT)
+	version_info['git_description'] = subprocess.check_output(['git', 'describe', '--dirty', '--tag', '--always'])
+	version_info['git_branch'] = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stderr=subprocess.STDOUT)
 
+	log_file = log_dir + file_root + '.log'
+	dashed_line = '-'*44
 
+	# Write array directories and command line arguments
+	with open(log_file, 'wb') as f:
+		f.write('#' + dashed_line + '\n# GitHub Info\n#' + dashed_line +'\n')
+		for key in version_info.keys():
+			f.write('%s: %s' %(key, version_info[key]))
+		f.write('\n\n')
+		f.write('#' + dashed_line + '\n# Directories\n#' + dashed_line +'\n')
+		f.write('Array save directory:\t%s\n' %(array_save_directory))
+		f.write('Multinest output file root:\t%s\n' %(file_root))
+		f.write('\n\n')
+		f.write('#' + dashed_line + '\n# Parser / Params Variables\n#' + dashed_line +'\n')
+		for key in p.__dict__.keys():
+			if not key.startswith('_'):
+				f.write('%s = %s\n' %(key, p.__dict__[key]))
 
-
-
-
-
-
-
-
+	print 'Log file written successfully to %s' %(log_file)

--- a/__init__.py
+++ b/__init__.py
@@ -52,6 +52,7 @@ from Utils import ExtractDataFrom21cmFASTCube, plot_signal_vs_MLsignal_residuals
 from Utils import generate_output_file_base, RenormaliseMatricesForScaledNoise
 from Utils import remove_unused_header_variables, construct_aplpy_image_from_fits
 from Utils import load_uvw_instrument_sampling_m, load_baseline_redundancy_array
+from Utils import write_log_file
 
 from GenerateForegroundCube import generate_Jelic_cube, generate_data_from_loaded_EoR_cube, generate_data_from_loaded_EoR_cube_v2d0
 from GenerateForegroundCube import generate_test_signal_from_image_cube

--- a/run_EoR.py
+++ b/run_EoR.py
@@ -359,6 +359,10 @@ else:
 	print 'run_single_node_analysis = {}\n'.format(run_single_node_analysis)
 
 if run_single_node_analysis or mpi_size>1:
+	# Write log file
+	if MPI.COMM_WORLD.Get_rank() == 0:
+		write_log_file(array_save_directory, file_root)
+
 	if use_MultiNest:
 		MN_nlive = nDims*25
 		# Run MultiNest


### PR DESCRIPTION
I think this log writing function will be important for keeping track of changes being implemented in the coming weeks.  I've tested it and everything seems to be working properly.  The git information in the log file will ultimately be the most important since a lot of the information from `params.py` is already stored in the array storage directory path and the MultiNest output filenames.  But, it's nice to have all of the tunable parameters in one document with all the corresponding paths and directories.

An example of a log file generated by this branch can be seen below:

```
#--------------------------------------------
# GitHub Info
#--------------------------------------------
git_hash: be1519dc91bb5e41fa1131e622b97913238aa7d1
git_description: be1519d-dirty
git_branch: log_writing
git_origin: https://github.com/PSims/BayesEoR.git


#--------------------------------------------
# Directories
#--------------------------------------------
Array save directory:	array_storage/batch_1/Likelihood_v1d76_3D_ZM_nu_9_nv_9_neta_38_nq_2_npl_2_b1_2.63E+00_b2_2.82E+00_sigma_8d5E+04_instrumental/HERA_331_baselines_shorter_than_29d3_for_30_0d5_min_time_steps_Gaussian_beam_peak_amplitude_1d0_beam_width_9d0_deg_at_150d0_MHz_dspb/
Multinest output file root:	MN-EoR-9_9_38_2_2_s_8d5E+04-lp_T-dPS_T_b1_2.63_b2_2.82-v18-


#--------------------------------------------
# Parser / Params Variables
#--------------------------------------------
instrument_model_directory_plus_beam_info = /users/jburba/data/jburba/bayes/BayesEoR/Instrument_Model/HERA_331_baselines_shorter_than_29d3_for_30_0d5_min_time_steps_Gaussian_beam_peak_amplitude_1d0_beam_width_9d0_deg_at_150d0_MHz/
EoR_analysis_cube_x_pix = 512
inverse_LW_power = 1e-16
channel_width_MHz = 0.2
FWHM_deg_at_ref_freq_MHz = 9.0
pl_grid_spacing = 0.1
beam_info_str = Gaussian_beam_peak_amplitude_1d0_beam_width_9d0_deg_at_150d0_MHz
beta_experimental_std_ff = 1e-10
EoR_npz_path_sc = /users/jburba/data/shared/PSims/BayesEoR_files_P/EoRsims/Hoag19/21cm_mK_z7.600_nf0.883_useTs0.0_aveTb21.06_cube_side_pix512_cube_side_Mpc2048.npz
use_freefree_foreground_cube = False
neta = 38
fits_storage_dir = fits_storage/multi_frequency_band_pythonPStest1/Jelic_nu_min_MHz_159d0_TbStd_66d1866884116_beta_2d63_dbeta0d02/
speed_of_light = 299792458.0
beam_type = Gaussian
pl_max = 3.0
Tb_experimental_mean_K_ff = 4.71
Tb_experimental_mean_K = 471.0
gamma_mean = -2.7
simulation_FoV_deg_ff = 12.0
uv_pixel_width_wavelengths = 2.5
box_size_21cmFAST_Mpc = 512
PB_ref_freq_MHz = 150.0
use_EGS_cube = False
use_nvis_nchan_nt_ordering = True
include_instrumental_effects = True
channel_width_MHz_ff = 0.2
useGPU = True
instrument_model_directory = /users/jburba/data/jburba/bayes/BayesEoR/Instrument_Model/HERA_331_baselines_shorter_than_29d3_for_30_0d5_min_time_steps/
EoR_analysis_cube_y_pix = 512
beta_experimental_mean_ff = 2.15
nf = 38
nx = 9
ny = 9
Tb_experimental_std_K = 66.1866884116
beta_experimental_std = 0.02
EoR_analysis_cube_y_Mpc = 2048
integration_time_minutes = 0.5
nq = 2
box_size_21cmFAST_pix = 128
gamma_sigma_ff = 0.04
nu = 9
nv = 9
gamma_sigma = 0.3
npl = 2
nu_min_MHz = 159.0
beta_experimental_mean = 2.63
EGS_npz_path = /users/psims/Cav/EoR/Missing_Radio_Flux/Surveys/Flux_Variance_Maps/S_Cubed/S_163_10nJy_Image_Cube_v34_18_deg_NV_1JyCN_With_Synchrotron_Self_Absorption/Fits/Flux_Density_Upper_Lim_1.0__Flux_Density_Lower_Lim_0.0/mk_cube/151_Flux_values_10NanoJansky_limit_data_result_18_Degree_Cube_RA_Dec_Degrees_and__10_pow_LogFlux_Columns_and_Source_Redshifts_and_Source_SI_and_Source_AGN_Type_Comb__mk.npz
pl_min = 2.0
use_intrinsic_noise_fitting = False
fit_for_spectral_model_parameters = False
model_drift_scan_primary_beam = True
use_nvis_nt_nchan_ordering = False
gamma_mean_ff = -2.59
beta = [2.63, 2.82]
simulation_resolution_deg_ff = 0.0234833659491
EoR_analysis_cube_x_Mpc = 2048
simulation_resolution_deg = 0.0234833659491
box_size_21cmFAST_Mpc_sc = 2048
simulation_FoV_deg = 12.0
constants = <module 'astropy.constants' from '/users/jburba/data/jburba/anaconda_stuff/anaconda2/envs/bayeseor/lib/python2.7/site-packages/astropy/constants/__init__.pyc'>
fit_for_monopole = False
argparse = <module 'argparse' from '/users/jburba/data/jburba/anaconda_stuff/anaconda2/envs/bayeseor/lib/python2.7/argparse.pyc'>
HF_nu_min_MHz_array = [220]
use_sparse_matrices = True
use_LWM_Gaussian_prior = False
HF_nu_min_MHz_array_ff = [210]
nt = 30
EoR_npz_path = /users/psims/EoR/EoR_simulations/21cmFAST_512MPc_512pix_128pix/Fits/21cm_z10d2_mK.npz
use_EoR_cube = True
beam_peak_amplitude = 1.0
integration_time_minutes_str = 0d5
nu_min_MHz_ff = 159.0
box_size_21cmFAST_pix_sc = 512
Tb_experimental_std_K_ff = 0.698184469839
use_uniform_prior_on_min_k_bin = False
use_GDSE_foreground_cube = False
fits_storage_dir_ff = fits_storage/free_free_emission/Free_free_nu_min_MHz_159d0_TbStd_0d698184469839_beta_2d15_dbeta1e-10/
sigma = 5000.0
```