### PR TITLE
Makefile for wrapmzpotrf.so

### DIFF
--- a/bayeseor/gpu/Makefile
+++ b/bayeseor/gpu/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-CFLAGS = -fPIC -O3 -Wall -Wextra
-LDFLAGS = -shared
+CFLAGS = -fPIC -O3 -Wall -Wextra -I${CONDA_PREFIX}/include/ -I${CONDA_PREFIX}/targets/x86_64-linux/include/
+LDFLAGS = -shared -L${CONDA_PREFIX}/lib/ -L${CONDA_PREFIX}/targets/x86_64-linux/lib
 
 TARGET = wrapmzpotrf.so
 

--- a/bayeseor/gpu/Makefile
+++ b/bayeseor/gpu/Makefile
@@ -1,0 +1,18 @@
+CC = gcc
+CFLAGS = -fPIC -O3 -Wall -Wextra
+LDFLAGS = -shared
+
+TARGET = wrapmzpotrf.so
+
+OBJECTS = wrapmzpotrf.o
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	    $(CC) $(LDFLAGS) -o $@ $^ -lmagma
+
+%.o: %.c
+	    $(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	    rm -f $(TARGET) $(OBJECTS)

--- a/bayeseor/gpu/wrapmzpotrf.c
+++ b/bayeseor/gpu/wrapmzpotrf.c
@@ -1,4 +1,4 @@
-
+#define ADD_ // MAGMA Fortran name mangling parameter
 #include <stdio.h>
 #include <stdlib.h>
 #include "cublas_v2.h"     // if you need CUBLAS, include before magma.h


### PR DESCRIPTION
- **fix: this flag is required by  in Ubuntu 22.04**
- **feat: simple Makefile to build wrapmzpotrf.so**
