### PR TITLE
feat: install magma and cuda with conda

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -20,3 +20,5 @@ dependencies:
   - setuptools
   - setuptools_scm
   - sphinx
+  - cuda
+  - magma


### PR DESCRIPTION
tested on Ubuntu 22.04 with A100 (Jetstream 2)
