### PR TITLE
build_T speedup using numpy threading 

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -22,3 +22,4 @@ dependencies:
   - setuptools
   - setuptools_scm
   - sphinx
+  - threadpoolctl


### PR DESCRIPTION
Changes made to address #43.  I found that, when using 16 cpus (threads), the built-in threading from numpy and using two nested for loops to do a series of dense * dense matrix multiplications is ~20 times faster than a serial computation using scipy.sparse on a single thread when calculating the T matrix (the largest matrix multiplication).  A comment has been added to `bayeseor.matrices/build_matrices.py` to explain the rationale behind this change.  A check has also been put in place in `bayeseor/matrices/build_matrices.py` to try and determine if more than 1 thread is available, otherwise the multiplication is done serially using scipy.sparse routines.

For reference, for a fixed N_u=15 for the EoR model, the table below shows the speedup resulting from this change in T calculation as a function of N_u used in the foreground (FG) model.

| N_u FG | sparse Walltime   | dense Walltime  |
| ------ | ----------------- | --------------- |
| 15     | 593 s             | 33 s            |
| 55     | 32881 s (9 hours) | 1247 s (20 min) |

I did a few checks of the compute time for T at different N_u FG values and found that the time to compute T scales approximately as $(N_u^{\rm{FG}})^3$, which I think is pretty typical for matrix multiplication routines.  For an all sky foreground model with a FoV=180 deg and N_u=155, this implies the compute time for T would be ~8 days.  With this speedup, it should only take about 7 hours to compute T with an all sky foreground model with 16 cpus/threads.

# Checks

I did one simple check using the T matrix built on the main branch, $\mathbf{T}$, and the T-speedup branch, $\mathbf{T}'$.  Subtracting the two matrices elementwise and then flattening the residuals, this plot shows the matrices computed on the two branches are identical to the 1e-21 level.

![image](https://github.com/user-attachments/assets/85708ec0-e821-4e59-9da0-43f5e60ea406)

# Changes

- Adds threadpoolctl as a dependency in BayesEoR/environment.yaml
- Checks threadpoolctl.threadpool_info() for the available number of threads, NTHREADS.  If NTHREADS > 1, the T matrix is computed using nested for loops and dense * dense matrix multiplications.  This way, each dense matrix multiplication can take advantage of threading to speed up the computation time and avoid using scipy.sparse's non-threading routines.