### PR TITLE
Various plotting improvements in bayeseor.utils.analyze_results

### DIFF
--- a/bayeseor/utils/analyze_results.py
+++ b/bayeseor/utils/analyze_results.py
@@ -46,8 +46,8 @@ class DataContainer(object):
         posterior distribution.
     ps_kind : str, optional
         Case insensitive power spectrum kind in the sampler output file.  Can
-        be 'ps' or 'dmps' for the power spectrum, P(k), or dimensionless power
-        spectrum, \Delta^2(k).  Defaults to 'dmps'.
+        be 'ps' or 'dmps' for the power spectrum, :math:`P(k)`, or
+        dimensionless power spectrum, :math:`\Delta^2(k)`.  Defaults to 'dmps'.
     temp_unit : str, optional
         Either 'mK' or 'K'.  The temperature unit of the power spectrum.  The
         default output from BayesEoR is 'mK' (default).
@@ -58,13 +58,13 @@ class DataContainer(object):
         output power spectra in little h units in the future.  This kwarg
         has thus been added for future use.
     expected_ps : float or array-like, optional
-        Expected power spectrum, P(k).  Can be a single float (for a flat P(k))
-        or an array-like with length equal to the number of spherically
-        averaged k bins.
+        Expected power spectrum, :math:`P(k)`.  Can be a single float (for a
+        flat :math:`P(k)`) or an array-like with length equal to the number of
+        spherically averaged k bins.
     expected_dmps : float or array-like, optional
-        Expected dimensionless power spectrum, \Delta^2(k).  Can be a single
-        float or an array-like with length equal to the number of spherically
-        averaged k bins.
+        Expected dimensionless power spectrum, :math:`\Delta^2(k)`.  Can be a
+        single float or an array-like with length equal to the number of
+        spherically averaged k bins.
     labels : array-like of str, optional
         Array-like containing strings with shorthand labels for each directory
         in `dirnames`.  Used in figure legends for plotting functions.
@@ -106,15 +106,15 @@ class DataContainer(object):
         # Units
         self.ps_kind = ps_kind.lower()
         self.temp_unit = temp_unit
-        self.k_units = "$h$ "*little_h_units + "Mpc$^{-1}$"
+        self.k_units = r"$h$ "*little_h_units + "Mpc$^{-1}$"
         if self.ps_kind == "ps":
-            self.ps_label = "$P(k)$"
+            self.ps_label = r"$P(k)$"
         else:
-            self.ps_label = "$\Delta^2(k)$"
+            self.ps_label = r"$\Delta^2(k)$"
         self.ps_units = (
-            f"{self.temp_unit}$^2$"
-            + " $h^{-3}$"*little_h_units
-            + " Mpc$^3$"*(self.ps_kind == "ps")
+            fr"{self.temp_unit}$^2$"
+            + r" $h^{-3}$"*little_h_units
+            + r" Mpc$^3$"*(self.ps_kind == "ps")
         )
 
         # Load contents of output directories
@@ -297,12 +297,12 @@ class DataContainer(object):
         Parameters
         ----------
         expected_ps : float or array-like, optional
-            Expected power spectrum, P(k).  Can be a single float (for a flat
-            P(k)) or an array-like with length equal to the number of
-            spherically averaged k bins.
+            Expected power spectrum, :math:`P(k)`.  Can be a single float (for
+            a flat :math:`P(k)`) or an array-like with length equal to the
+            number of spherically averaged k bins.
         expected_dmps : float or array-like, optional
-            Expected dimensionless power spectrum, \Delta^2(k).  Can be a
-            single float or an array-like with length equal to the number of
+            Expected dimensionless power spectrum, :math:`\Delta^2(k)`.  Can be
+            a single float or an array-like with length equal to the number of
             spherically averaged k bins.
 
         """        
@@ -356,7 +356,7 @@ class DataContainer(object):
     
     def _ps_to_dmps(self, ps, ks):
         """
-        Convert P(k) to \Delta^2(k).
+        Convert :math:`P(k)` to :math:`\Delta^2(k)`.
 
         Parameters
         ----------
@@ -371,7 +371,7 @@ class DataContainer(object):
     
     def _dmps_to_ps(self, dmps, ks):
         """
-        Convert \Delta^2(k) to P(k).
+        Convert :math:`\Delta^2(k)` to :math:`P(k)`.
 
         Parameters
         ----------

--- a/bayeseor/utils/analyze_results.py
+++ b/bayeseor/utils/analyze_results.py
@@ -103,7 +103,10 @@ class DataContainer(object):
         if self.sampler == 'multinest':
             self.sampler_filename = "data-.txt"
         self.labels = labels
-        self.calc_uplims = calc_uplims
+        if uplim_inds is not None:
+            self.calc_uplims = True
+        else:
+            self.calc_uplims = calc_uplims
         self.quantile = quantile
         self.uplim_inds = uplim_inds
         self.calc_kurtosis = calc_kurtosis

--- a/bayeseor/utils/analyze_results.py
+++ b/bayeseor/utils/analyze_results.py
@@ -50,6 +50,9 @@ class DataContainer(object):
         limits.  Defaults to False.
     Nhistbins : int, optional
         Number of histogram bins for each k bin's posterior distribution.
+    density : bool, optional
+            If `density` is True, compute the posterior as a probability
+            density function.  Defaults to False, i.e. plot counts.
     calc_kurtosis : bool, optional
         If `calc_kurtosis` is True, calculate the kurtosis of each k bin's
         posterior distribution.
@@ -92,6 +95,7 @@ class DataContainer(object):
         uplim_inds=None,
         posterior_weighted=False,
         Nhistbins=31,
+        density=False,
         calc_kurtosis=False,
         ps_kind="dmps",
         temp_unit="mK",
@@ -177,6 +181,7 @@ class DataContainer(object):
                 conf_intervals=conf_intervals,
                 uplim_quantile=self.uplim_quantile,
                 Nhistbins=Nhistbins,
+                density=density,
                 log_priors=args.log_priors,
                 return_samples=store_samples
             )
@@ -215,6 +220,7 @@ class DataContainer(object):
         conf_intervals=[68, 95],
         uplim_quantile=0.95,
         Nhistbins=31,
+        density=False,
         log_priors=True,
         return_samples=False
     ):
@@ -241,6 +247,9 @@ class DataContainer(object):
         Nhistbins : int, optional
             Number of histogram bins for each k bin's posterior distribution.
             Defaults to 31.
+        density : bool, optional
+            If `density` is True, compute the posterior as a probability
+            density function.  Defaults to False, i.e. plot counts.
         log_priors : bool, optional
             If `log_priors` is True (default), power spectrum samples are
             assumed to be in log10 units and are first linearized prior to
@@ -322,7 +331,7 @@ class DataContainer(object):
                 posteriors[i_k], bins[i_k] = np.histogram(
                     data[:, 2 + i_k],
                     bins=bins[i_k],
-                    density=True,  # return the PDF
+                    density=density,
                     weights=weights
                 )
                 if self.calc_kurtosis:

--- a/bayeseor/utils/analyze_results.py
+++ b/bayeseor/utils/analyze_results.py
@@ -322,6 +322,7 @@ class DataContainer(object):
                 posteriors[i_k], bins[i_k] = np.histogram(
                     data[:, 2 + i_k],
                     bins=bins[i_k],
+                    density=True,  # return the PDF
                     weights=weights
                 )
                 if self.calc_kurtosis:


### PR DESCRIPTION
Updated `bayeseor/utils/analyze_results.py`.  The largest changes are using confidence intervals instead of the standard deviation for uncertainties and adding a kwarg toggle for using the joint posterior as weights for determining power spectrum estimates and uncertainties.

Using a standard deviation as the uncertainty measurement implies Gaussianity of the posteriors for each power spectrum coefficient.  Using confidence intervals is distribution agnostic and a safer alternative.  This means that uncertainties now have separate plus and minus values.  The confidence intervals can be set via the `conf_intervals` kwarg which accepts either a single float or a list of floats, in which case multiple confidence intervals are calculated and stored.

I think uniformly weighting the data, i.e. _not_ using the joint posterior as weights, is a safer and potentially more accurate option for deriving power spectrum estimates and uncertainties directly from the samples.  The samples themselves are already weighted by the posterior during sampling in terms of how frequently a given sample occurs.  A kwarg `posterior_weighted` has been added which allows the user to toggle the joint posterior as the weights (True) or to use uniform weighting (False, default).

The other changes are more minor and add convenience and some extra plotting utility which was found to be recently useful in my own analyses.

# Changes

1. Add kwarg for storing samples (`store_samples`, fixes #35)
2. Add kwarg for plotting priors (`plot_priors`, fixes #41)
3. Add kwarg for toggling the joint posterior as weights (`posterior_weighted`)
4. Force `calc_uplims = True` if passing `uplim_inds` (fixes #38)
5. Use confidence intervals instead of standard deviation for uncertainties
6. Add kwarg (`density`) to plot posteriors as counts (False, default) or PDFs (True)