### PR TITLE
Fix monopole indexing and conditional FG reordering

### DIFF
--- a/bayeseor/matrices/build.py
+++ b/bayeseor/matrices/build.py
@@ -1331,14 +1331,9 @@ class BuildMatrices():
         )
         nuidft_array = nuidft_matrix_2d(
             self.nu_fg, self.nv_fg, self.du_fg, self.dv_fg,
-            ls_rad, ms_rad, exclude_mean=False
+            ls_rad, ms_rad, exclude_mean=(not self.fit_for_monopole)
         )
         nuidft_array *= self.Fprime_normalization_fg
-        if self.fit_for_monopole:
-            mp_col = nuidft_array[:, self.nuv_fg//2].copy().reshape(-1, 1)
-        nuidft_array = np.delete(nuidft_array, self.nuv_fg//2, axis=1)
-        if self.fit_for_monopole:
-            nuidft_array = np.hstack((nuidft_array, mp_col))
         multi_chan_nuidft_fg = self.sd_block_diag(
             [nuidft_array for _ in range(self.nf)]
         )

--- a/bayeseor/matrices/funcs.py
+++ b/bayeseor/matrices/funcs.py
@@ -28,7 +28,9 @@ def sampled_uv_vectors(nu, nv, du=1.0, dv=1.0, exclude_mean=True):
     exclude_mean : bool
         If True, remove the (u, v) = (0, 0) pixel from the model
         uv-plane coordinate arrays. If False, keep the (u, v) = (0, 0)
-        pixel and move it to the rightmost column. Defaults to True.
+        pixel and move it to the rightmost column so it sits next to the
+        LSSM components in the model vector, since the monopole acts as the
+        constant term. Defaults to True.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
This PR fixes monopole handling so `(u,v)=(0,0)` is identified by value rather than midpoint index, and centralizes FG monopole ordering in one place.

## Changes
- Update `sampled_uv_vectors` to detect monopole via `(u==0) & (v==0)`.
- `exclude_mean=True`: remove monopole by mask.
- `exclude_mean=False`: keep monopole and move it to the rightmost column.
- Remove separate FG reordering logic from `build_Finv_Fprime` (no more `nuv_fg//2` index assumption).
- All implemented before DFT creation in creation of `uv_vectors`

## Why
- Midpoint deletion (`(nu*nv)//2`) is only correct for odd-by-odd grids.
- For even grids, midpoint and monopole indices differ, causing incorrect mode deletion/reordering.
- Consolidating deletion/reordering in `sampled_uv_vectors` keeps downstream ordering consistent.

## Validation
- Verified on an even-grid check (`nu=nv=4`) that:
  - `exclude_mean=True` removes `(0,0)`.
  - `exclude_mean=False` keeps `(0,0)` and places it in the last column.
## Issue Coverage

This PR also addresses the behavior discussed in:

- #68
- #69 