### PR TITLE
Add tests and targeted Pyright fixes for core modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-deps -e ".[dev]"
-          python -m pip install astropy astropy-healpix h5py jsonargparse numpy pyuvdata pytest rich ruff scipy
+          python -m pip install astropy astropy-healpix h5py jsonargparse matplotlib numpy pyuvdata pytest rich ruff scipy
 
       - name: Lint
         run: ruff check bayeseor/model tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install package and test dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: local
+    hooks:
+      - id: trim-trailing-whitespace
+        name: trim trailing whitespace
+        entry: python scripts/precommit_trim_trailing_whitespace.py
+        language: system
+        types: [text]
+        files: ^(bayeseor/(model/|utils\.py|cosmology\.py|gpu\.py|posterior\.py)|tests/|scripts/precommit_.*\.py|CONTRIBUTING\.md|README\.md|environment\.yaml|pyproject\.toml|pyrightconfig\.json|\.pre-commit-config\.yaml|\.readthedocs\.yaml|\.github/.*\.(yml|yaml))
+
+      - id: fix-end-of-file
+        name: fix end of file
+        entry: python scripts/precommit_fix_end_of_file.py
+        language: system
+        types: [text]
+        files: ^(bayeseor/(model/|utils\.py|cosmology\.py|gpu\.py|posterior\.py)|tests/|scripts/precommit_.*\.py|CONTRIBUTING\.md|README\.md|environment\.yaml|pyproject\.toml|pyrightconfig\.json|\.pre-commit-config\.yaml|\.readthedocs\.yaml|\.github/.*\.(yml|yaml))
+
+      - id: check-yaml-local
+        name: check yaml
+        entry: python scripts/precommit_check_yaml.py
+        language: system
+        files: \.(yaml|yml)$
+
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --fix
+        language: system
+        types: [python]
+        files: ^(bayeseor/(model/|utils\.py|cosmology\.py|gpu\.py|posterior\.py)|tests/)
+
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format
+        language: system
+        types: [python]
+        files: ^(bayeseor/(model/|utils\.py|cosmology\.py|gpu\.py|posterior\.py)|tests/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ Install BayesEoR in editable mode with development tools:
 python -m pip install -e ".[dev]"
 ```
 
+The `dev` and `test` extras include the plotting dependency needed by the
+analysis-related tests.
+
 Install the local git hooks with:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,22 @@ mamba env update -n bayeseor -f environment.yaml --prune
 
 If you prefer `conda`, replace `mamba` with `conda` in the commands above.
 
+Activate the environment:
+
+```bash
+conda activate bayeseor
+```
+
 Install BayesEoR in editable mode with development tools:
 
 ```bash
-conda run -n bayeseor python -m pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
+```
+
+Install the local git hooks with:
+
+```bash
+pre-commit install
 ```
 
 ## Testing
@@ -29,14 +41,23 @@ conda run -n bayeseor python -m pip install -e ".[dev]"
 Run the test suite with:
 
 ```bash
-conda run --no-capture-output -n bayeseor python -m pytest
+python -m pytest
 ```
 
 You can run lint checks with:
 
 ```bash
-conda run --no-capture-output -n bayeseor ruff check bayeseor/model tests
+ruff check bayeseor/model tests
 ```
+
+You can also run the configured pre-commit hooks across the repository with:
+
+```bash
+pre-commit run --all-files
+```
+
+For CI or other non-interactive shells, `conda run -n bayeseor ...` is still a
+good alternative to activating the environment first.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python scripts/run-analysis.py --config /path/to/config.yaml
 
 # Citation
 
-Users of the code are requested to cite the BayesEoR papers: 
+Users of the code are requested to cite the BayesEoR papers:
 
 - [Sims et al. 2016](https://ui.adsabs.harvard.edu/abs/2016MNRAS.462.3069S/abstract)
 - [Sims et al. 2019a](https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.4152S/abstract)

--- a/bayeseor/analyze/analyze.py
+++ b/bayeseor/analyze/analyze.py
@@ -3,9 +3,25 @@ import numpy as np
 import scipy as sp
 from pathlib import Path
 import json
+from typing import TypeAlias, cast
 from jsonargparse import Namespace
 from collections.abc import Iterable
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from numpy.typing import NDArray
+
+PosteriorIntervalBounds: TypeAlias = dict[str, NDArray[np.float64]]
+PosteriorCredibleIntervals: TypeAlias = dict[float, PosteriorIntervalBounds]
+PosteriorDataReturn: TypeAlias = tuple[
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    PosteriorCredibleIntervals,
+    NDArray[np.float64] | None,
+    NDArray[np.float64] | None,
+    NDArray[np.float64] | None,
+]
 
 
 class DataContainer(object):
@@ -191,10 +207,13 @@ class DataContainer(object):
             self.medians.append(out[3])
             self.cred_intervals.append(out[4])
             if self.calc_uplims:
+                assert out[5] is not None
                 self.uplims.append(out[5])
             if self.calc_kurtosis:
+                assert out[6] is not None
                 self.kurtoses.append(out[6])
             if store_samples:
+                assert out[7] is not None
                 self.samples.append(out[7][:, 2:])
                 self.log_joint_posteriors.append(out[7][:, 0])
         
@@ -211,6 +230,14 @@ class DataContainer(object):
             self.calculate_expected_ps(
                 expected_ps=expected_ps, expected_dmps=expected_dmps
             )
+
+    @staticmethod
+    def _normalize_axes(axs: Axes | NDArray[np.object_] | Iterable[Axes]) -> list[Axes]:
+        if isinstance(axs, np.ndarray):
+            return [cast(Axes, ax) for ax in axs.flat]
+        if isinstance(axs, Iterable) and not isinstance(axs, Axes):
+            return [cast(Axes, ax) for ax in axs]
+        return [axs]
     
     def get_posterior_data(
         self,
@@ -223,7 +250,7 @@ class DataContainer(object):
         density=False,
         log_priors=True,
         return_samples=False
-    ):
+    ) -> PosteriorDataReturn:
         """
         Load sampler output and form posteriors for each k bin.
 
@@ -300,30 +327,46 @@ class DataContainer(object):
                 weights = data[:, 0]
             else:
                 weights = None
-            avgs = np.average(data[:, 2:], axis=0, weights=weights)
-            medians = self._weighted_quantiles(
-                data[:, 2:], 0.5, weights=weights
+            avgs = np.asarray(
+                np.average(data[:, 2:], axis=0, weights=weights),
+                dtype=float,
             )
-            ci_dict = {}
+            medians = np.asarray(
+                self._weighted_quantiles(data[:, 2:], 0.5, weights=weights),
+                dtype=float,
+            )
+            ci_dict: PosteriorCredibleIntervals = {}
             for ci in cred_intervals:
                 quantile = (ci/2 + 50) / 100
-                lobounds = self._weighted_quantiles(
-                    data[:, 2:], 1 - quantile, weights=weights
+                lobounds = np.asarray(
+                    self._weighted_quantiles(
+                        data[:, 2:], 1 - quantile, weights=weights
+                    ),
+                    dtype=float,
                 )
-                hibounds = self._weighted_quantiles(
-                    data[:, 2:], quantile, weights=weights
+                hibounds = np.asarray(
+                    self._weighted_quantiles(
+                        data[:, 2:], quantile, weights=weights
+                    ),
+                    dtype=float,
                 )
                 ci_dict[ci] = {'lo': lobounds, 'hi': hibounds}
+            uplims: NDArray[np.float64] | None = None
             if self.calc_uplims:
-                uplims = self._weighted_quantiles(
-                    data[:, 2:],
-                    uplim_quantile,
-                    weights=weights
+                uplims = np.asarray(
+                    self._weighted_quantiles(
+                        data[:, 2:],
+                        uplim_quantile,
+                        weights=weights
+                    ),
+                    dtype=float,
                 )
 
             posteriors = np.zeros((Nkbins, Nhistbins), dtype=float)
             bins = np.zeros((Nkbins, Nhistbins + 1), dtype=float)
-            kurtoses = np.zeros(Nkbins, dtype=float)
+            kurtoses: NDArray[np.float64] | None = None
+            if self.calc_kurtosis:
+                kurtoses = np.zeros(Nkbins, dtype=float)
             for i_k in range(data[0, 2:].size):
                 bins_min = data[:, 2 + i_k].min()
                 bins_max = data[:, 2 + i_k].max()
@@ -337,26 +380,24 @@ class DataContainer(object):
                     density=density,
                     weights=weights
                 )
-                if self.calc_kurtosis:
+                if self.calc_kurtosis and kurtoses is not None:
                     kurtoses[i_k] = sp.stats.kurtosis(posteriors[i_k])
         else:
-            print("'multinest' is currently the only supported sampler.")
-            return
+            raise NotImplementedError(
+                "'multinest' is currently the only supported sampler."
+            )
         
-        return_vals = (posteriors, bins, avgs, medians, ci_dict)
-        if self.calc_uplims:
-            return_vals += (uplims,)
-        else:
-            return_vals += (None,)
-        if self.calc_kurtosis:
-            return_vals += (kurtoses,)
-        else:
-            return_vals += (None,)
-        if return_samples:
-            return_vals += (data,)
-        else:
-            return_vals += (None,)
-        return return_vals
+        samples = data if return_samples else None
+        return (
+            posteriors,
+            bins,
+            avgs,
+            medians,
+            ci_dict,
+            uplims,
+            kurtoses,
+            samples,
+        )
 
     def calculate_expected_ps(self, expected_ps=None, expected_dmps=None):
         """
@@ -615,10 +656,12 @@ class DataContainer(object):
                         np.zeros(self.k_vals[i_dir].shape, dtype=bool)
                     )
 
-        external_call = np.all([x is not None for x in [fig, axs]])
+        external_call = fig is not None and axs is not None
         if external_call:
             # Being used by `self.plot_power_spectra_and_posteriors`
-            subplots = len(axs) > 1
+            assert axs is not None
+            axs_list = self._normalize_axes(axs)
+            subplots = len(axs_list) > 1
         else:
             subplots = plot_diff or plot_fracdiff and self.has_expected
             if subplots:
@@ -637,6 +680,8 @@ class DataContainer(object):
                 figsize = (fig_width, fig_height)
                 fig, ax = plt.subplots(figsize=figsize)
                 axs = [ax]
+            axs_list = self._normalize_axes(axs)
+        assert fig is not None
         
         if cmap is not None:
             colors = cmap(np.linspace(0, 1, self.Ndirs))
@@ -646,17 +691,23 @@ class DataContainer(object):
         if self.Ndirs > 1 and x_offset == 0 and zorder_offset == 0:
             zorder_offset = 1
 
-        ax = axs[0]
+        ax = axs_list[0]
         ax.set_yscale("log")
         if subplots:
-            ax_diff = axs[1]
+            ax_diff = axs_list[1]
         if self.has_expected:
             if self.ps_kind == "ps":
                 expected = self.expected_ps
             else:
                 expected = self.expected_dmps
+            assert expected is not None
             plot_expected = True
             i_exp = 0
+        assert uplim_inds is not None
+        diff_uplim_yerr = (
+            np.abs(np.asarray(ylim_diff if ylim_diff is not None else [-1, 1])).max()
+            / 2
+        )
 
         for i_dir in range(self.Ndirs):
             if self.has_expected:
@@ -732,7 +783,7 @@ class DataContainer(object):
                                 self.uplims[i_dir][upl_inds]
                                 - expected[i_exp][upl_inds]
                             )
-                            diff_err[1, upl_inds] = np.abs(ylim_diff).max() / 2
+                            diff_err[1, upl_inds] = diff_uplim_yerr
                     else:
                         diff = self.medians[i_dir] / expected[i_exp] - 1
                         diff_err = yerr / expected[i_exp]
@@ -742,7 +793,7 @@ class DataContainer(object):
                                 / expected[i_exp][upl_inds]
                             )
                             diff[upl_inds] -= 1
-                            diff_err[1, upl_inds] = np.abs(ylim_diff).max() / 2
+                            diff_err[1, upl_inds] = diff_uplim_yerr
 
                     ax_diff.errorbar(
                         xs[upl_inds],
@@ -815,7 +866,7 @@ class DataContainer(object):
         if subplots and ylim_diff is not None:
             ax_diff.set_ylim(ylim_diff)
         
-        for ax_i in axs:
+        for ax_i in axs_list:
             ax_i.grid()
             ax_i.set_xscale("log")
         
@@ -844,7 +895,7 @@ class DataContainer(object):
         
             return fig
         else:
-            return axs
+            return axs_list
 
     def plot_posteriors(
         self,
@@ -913,7 +964,7 @@ class DataContainer(object):
             `self.plot_power_spectra_and_posteriors`.
 
         """
-        external_call = np.all([x is not None for x in [fig, axs]])
+        external_call = fig is not None and axs is not None
         if not external_call:
             # Not being used by `self.plot_power_spectra_and_posteriors`
             # This plot is only useful for comparing power spectrum analyses
@@ -927,6 +978,9 @@ class DataContainer(object):
                 Nkbins, 1, figsize=figsize, sharex=True,
                 gridspec_kw=gridspec_kw
             )
+        assert fig is not None
+        assert axs is not None
+        axs_list = self._normalize_axes(axs)
 
         if cmap is not None:
             colors = cmap(np.linspace(0, 1, self.Ndirs))
@@ -938,9 +992,10 @@ class DataContainer(object):
                 expected = self.expected_ps
             else:
                 expected = self.expected_dmps
+            assert expected is not None
 
         for i_dir in range(self.Ndirs):
-            for i_k, ax in enumerate(axs):
+            for i_k, ax in enumerate(axs_list):
                 ax.stairs(
                     self.posteriors[i_dir][i_k],
                     self.posterior_bins[i_dir][i_k],
@@ -973,7 +1028,7 @@ class DataContainer(object):
                         )
                     ax.set_xscale("log")
                     if log_y:
-                        ax.set_ylim([ymin, ax.get_ylim()[1]])
+                        ax.set_ylim((ymin, ax.get_ylim()[1]))
                         ax.set_yscale("log")
                 if plot_priors:
                     prior_lo = self.args[i_dir].priors[i_k][0]
@@ -988,7 +1043,7 @@ class DataContainer(object):
                         alpha=0.3,
                         zorder=0
                     )
-        ax.set_xlabel(fr"{self.ps_label} [{self.ps_units}]")
+        axs_list[-1].set_xlabel(fr"{self.ps_label} [{self.ps_units}]")
 
         if not external_call:
             ylabel = "Power Spectrum Coefficient Posterior Distributions"
@@ -999,7 +1054,7 @@ class DataContainer(object):
                 fig.suptitle(suptitle)
             return fig
         else:
-            return axs
+            return axs_list
 
     def plot_power_spectra_and_posteriors(
         self,
@@ -1160,8 +1215,8 @@ class DataContainer(object):
             Figure suptitle string.  Defaults to None.
 
         """
-        subplots_ps = np.any([plot_diff, plot_fracdiff])
-        Nplots_ps = 1 + subplots_ps
+        subplots_ps = bool(np.any([plot_diff, plot_fracdiff]))
+        Nplots_ps = 1 + int(subplots_ps)
         Nkbins = self.k_vals[0].size
         plots_height_ps = (
             plot_height_ps

--- a/bayeseor/analyze/maxap.py
+++ b/bayeseor/analyze/maxap.py
@@ -1,17 +1,21 @@
 """ Class and functions for performing maximum a posteriori calculations. """
 import numpy as np
 from numpy.typing import ArrayLike
+from typing import Literal, cast, overload
 from astropy import units
 from astropy.time import Time
 from pathlib import Path
 from pprint import pprint
-import matplotlib.pyplot as plt
 
 from rich.panel import Panel
 
 from ..params import BayesEoRParser
 from ..setup import run_setup
 from ..utils import mpiprint
+
+FloatArray = np.ndarray[tuple[int], np.dtype[np.float64]]
+ComplexArray = np.ndarray[tuple[int], np.dtype[np.complex128]]
+
 
 class MaximumAPosteriori(object):
     """
@@ -88,7 +92,7 @@ class MaximumAPosteriori(object):
             )
             if array_dirs_differ:
                 mpiprint(
-                    f"\nReplacing array_dir:",
+                    "\nReplacing array_dir:",
                     style="bold",
                     end="\n\n",
                     rank=print_rank
@@ -137,6 +141,22 @@ class MaximumAPosteriori(object):
         if "antpairs" in vis_dict:
             self.antpairs = vis_dict["antpairs"]
     
+    @overload
+    def map_estimate(
+        self,
+        ps: float | ArrayLike | None = None,
+        dmps: float | ArrayLike | None = None,
+        return_prior_cov: Literal[False] = False,
+    ) -> tuple[FloatArray, ComplexArray, float]: ...
+
+    @overload
+    def map_estimate(
+        self,
+        ps: float | ArrayLike | None = None,
+        dmps: float | ArrayLike | None = None,
+        return_prior_cov: Literal[True] = True,
+    ) -> tuple[FloatArray, ComplexArray, float, FloatArray]: ...
+
     def map_estimate(
         self,
         ps : float | ArrayLike | None = None,
@@ -183,11 +203,11 @@ class MaximumAPosteriori(object):
         """
         if ps is None and dmps is None:
             raise ValueError("One of 'ps' or 'dmps' must not be None")
-        dmps = self.calculate_dmps(ps=ps, dmps=dmps)
+        dmps_array = self.calculate_dmps(ps=ps, dmps=dmps)
 
         map_coeffs, dbar_SigmaI_dbar, prior_cov, log_det_Sigma = \
             self.pspp.calc_SigmaI_dbar_wrapper(
-                dmps,
+                dmps_array,
                 self.pspp.T_Ninv_T,
                 self.pspp.dbar
             )
@@ -200,7 +220,7 @@ class MaximumAPosteriori(object):
             + 0.5*dbar_SigmaI_dbar
         )
         if self.pspp.uprior_inds is not None:
-            log_post += np.sum(np.log(dmps[self.pspp.uprior_inds]))
+            log_post += np.sum(np.log(dmps_array[self.pspp.uprior_inds]))
         log_post = log_post.real
 
         if not return_prior_cov:
@@ -212,7 +232,7 @@ class MaximumAPosteriori(object):
         self,
         ps : float | ArrayLike | None = None,
         dmps : float | ArrayLike | None = None
-    ):
+    ) -> FloatArray:
         r"""
         Calculate the prior covariance matrix :math:`\Phi^{-1}`.
 
@@ -236,16 +256,16 @@ class MaximumAPosteriori(object):
         """
         if ps is None and dmps is None:
             raise ValueError("One of 'ps' or 'dmps' must not be None")
-        dmps = self.calculate_dmps(ps=ps, dmps=dmps)
-        PhiI = self.pspp.calc_PowerI(dmps)
+        dmps_array = self.calculate_dmps(ps=ps, dmps=dmps)
+        PhiI = self.pspp.calc_PowerI(dmps_array)
 
-        return PhiI
+        return np.asarray(PhiI, dtype=float)
     
     def calculate_dmps(
         self,
         ps : float | ArrayLike | None = None,
         dmps : float | ArrayLike | None = None
-    ):
+    ) -> FloatArray:
         r"""
         Calculated the expected dimensionless power spectrum.
 
@@ -273,27 +293,38 @@ class MaximumAPosteriori(object):
 
         if ps is not None:
             if hasattr(ps, "__iter__"):
-                ps = np.array(ps)
-                assert ps.size == self.k_vals.size, (
-                    f"'ps' has a size {ps.size} which is not "
+                ps_array = np.asarray(ps, dtype=float)
+                assert ps_array.size == self.k_vals.size, (
+                    f"'ps' has a size {ps_array.size} which is not "
                     f"equal to the number of k bins, {self.k_vals.size}"
                 )
             else:
                 # Flat P(k)
-                ps *= np.ones_like(self.k_vals)
-            dmps = self.k_vals**3 / (2 * np.pi**2) * ps
-        if dmps is not None:
-            if hasattr(dmps, "__iter__"):
-                dmps = np.array(dmps)
-                assert dmps.size == self.k_vals.size, (
-                    f"'dmps' has a size {dmps.size} which is "
-                    f"not equal to the number of k bins, {self.k_vals.size}"
+                ps_array = float(cast(float, ps)) * np.ones_like(
+                    self.k_vals,
+                    dtype=float,
                 )
-            else:
-                # Flat \Delta^2(k)
-                dmps *= np.ones_like(self.k_vals)
+            dmps_array = np.asarray(
+                self.k_vals**3 / (2 * np.pi**2) * ps_array,
+                dtype=float,
+            )
+            return dmps_array
 
-        return dmps
+        assert dmps is not None
+        if hasattr(dmps, "__iter__"):
+            dmps_array = np.asarray(dmps, dtype=float)
+            assert dmps_array.size == self.k_vals.size, (
+                f"'dmps' has a size {dmps_array.size} which is "
+                f"not equal to the number of k bins, {self.k_vals.size}"
+            )
+        else:
+            # Flat \Delta^2(k)
+            dmps_array = float(cast(float, dmps)) * np.ones_like(
+                self.k_vals,
+                dtype=float,
+            )
+
+        return dmps_array
 
     def extract_bl_vis(self, vis_vec : np.ndarray):
         """

--- a/bayeseor/cosmology.py
+++ b/bayeseor/cosmology.py
@@ -11,6 +11,7 @@ class Cosmology:
     calculations using `astropy.cosmology.Planck18`.
 
     """
+
     def __init__(self) -> None:
         self.cosmo: Any = Planck18
         self.Om0: float = float(cast(Any, self.cosmo).Om0)
@@ -125,5 +126,5 @@ class Cosmology:
             Volume conversion factor for sr Hz --> Mpc^3 at redshift `z`.
 
         """
-        i2cV = self.dL_dth(z)**2 * self.dL_df(z)
+        i2cV = self.dL_dth(z) ** 2 * self.dL_df(z)
         return i2cV

--- a/bayeseor/cosmology.py
+++ b/bayeseor/cosmology.py
@@ -1,7 +1,9 @@
-from astropy import units
-from astropy.units import Quantity
-from astropy.constants import c
+from typing import Any, cast
+
+from astropy import constants as const, units
 from astropy.cosmology import Planck18
+from astropy.units import Quantity
+
 
 class Cosmology:
     """
@@ -9,16 +11,16 @@ class Cosmology:
     calculations using `astropy.cosmology.Planck18`.
 
     """
-    def __init__(self):
-        self.cosmo = Planck18
-        self.Om0 = self.cosmo.Om0
-        self.Ode0 = self.cosmo.Ode0
-        self.Ok0 = self.cosmo.Ok0
-        self.H0 = self.cosmo.H0
-        self.c = c.to('m/s')
-        self.f_21 = 1420.40575177 * units.MHz
+    def __init__(self) -> None:
+        self.cosmo: Any = Planck18
+        self.Om0: float = float(cast(Any, self.cosmo).Om0)
+        self.Ode0: float = float(cast(Any, self.cosmo).Ode0)
+        self.Ok0: float = float(cast(Any, self.cosmo).Ok0)
+        self.H0: Quantity = cast(Quantity, cast(Any, self.cosmo).H0)
+        self.c: Quantity = cast(Quantity, const.c.to("m/s"))  # pyright: ignore
+        self.f_21: Quantity = cast(Quantity, 1420.40575177 * units.MHz)
 
-    def f2z(self, f):
+    def f2z(self, f: float | Quantity) -> float:
         """
         Convert a frequency `f` in Hz to redshift
         relative to `self.f_21`.
@@ -35,12 +37,13 @@ class Cosmology:
 
         """
         if not isinstance(f, Quantity):
-            f *= units.Hz
+            freq_hz = float(f)
         else:
-            f = f.to('Hz')
-        return (self.f_21/f - 1).value
+            freq_hz = float(cast(Any, f).to_value(units.Hz))
+        f_21_hz = float(cast(Any, self.f_21).to_value(units.Hz))
+        return f_21_hz / freq_hz - 1.0
 
-    def z2f(self, z):
+    def z2f(self, z: float) -> float:
         """
         Convert a redshift `z` relative to `self.f_21`
         to a frequency in Hz.
@@ -56,9 +59,10 @@ class Cosmology:
             Frequency corresponding to redshift `z`.
 
         """
-        return (self.f_21 / (1 + z)).to('Hz').value
+        f_21_hz = float(cast(Any, self.f_21).to_value(units.Hz))
+        return f_21_hz / (1 + z)
 
-    def dL_df(self, z):
+    def dL_df(self, z: float) -> float:
         """
         Comoving differential distance at redshift per frequency.
 
@@ -74,12 +78,17 @@ class Cosmology:
             Mpc at redshift `z`.
 
         """
-        d_h = self.c.to('km/s') / self.H0  # Hubble distance
-        e_z = self.cosmo.efunc(z)
-        dl_df = d_h / e_z * (1 + z)**2 / self.f_21.to('Hz')
-        return dl_df.value
+        c_km_s = float(cast(Any, self.c).to_value(units.km / units.s))
+        h0_km_s_mpc = float(
+            cast(Any, self.H0).to_value(units.km / (units.s * units.Mpc))
+        )
+        d_h_mpc = c_km_s / h0_km_s_mpc
+        e_z = float(cast(Any, self.cosmo).efunc(z))
+        f_21_hz = float(cast(Any, self.f_21).to_value(units.Hz))
+        dl_df = d_h_mpc / e_z * (1 + z) ** 2 / f_21_hz
+        return dl_df
 
-    def dL_dth(self, z):
+    def dL_dth(self, z: float) -> float:
         """
         Comoving transverse distance per radian in Mpc.
 
@@ -96,10 +105,10 @@ class Cosmology:
             at redshift `z`.
 
         """
-        dl_dth = self.cosmo.comoving_transverse_distance(z)
-        return dl_dth.value
+        dl_dth = cast(Any, self.cosmo).comoving_transverse_distance(z)
+        return float(cast(Any, dl_dth).to_value(units.Mpc))
 
-    def inst_to_cosmo_vol(self, z):
+    def inst_to_cosmo_vol(self, z: float) -> float:
         """
         Conversion factor to go from an instrumentally
         sampled volume in sr Hz to a comoving cosmological

--- a/bayeseor/gpu.py
+++ b/bayeseor/gpu.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from sysconfig import get_paths
+from typing import Any, cast
 
 import numpy as np
 
 from .utils import mpiprint
 
 
-class GPUInterface(object):
+class GPUInterface:
     """
     Class to interface with GPUs.
 
@@ -22,7 +23,12 @@ class GPUInterface(object):
 
     """
 
-    def __init__(self, base_dir=None, rank=0, verbose=True):
+    def __init__(
+        self,
+        base_dir: str | Path | None = None,
+        rank: int = 0,
+        verbose: bool = True,
+    ) -> None:
         if base_dir is None:
             # Look for MAGMA .so files in environment's lib directory
             self.base_dir = Path(get_paths()["stdlib"]).parent
@@ -33,11 +39,13 @@ class GPUInterface(object):
 
         try:
             import ctypes
+            import importlib
 
-            import pycuda.autoinit
             import pycuda.driver as cuda
             from numpy import ctypeslib
 
+            importlib.import_module("pycuda.autoinit")
+            cuda_driver = cast(Any, cuda)
             so_path = self.base_dir / "libmagma.so"
             if self.verbose:
                 mpiprint(
@@ -74,10 +82,11 @@ class GPUInterface(object):
             ]
             if self.verbose:
                 mpiprint("Computing on GPU(s)", rank=self.rank)
-                Ngpus = cuda.Device.count()
+                device_cls = cuda_driver.Device
+                ngpus = int(device_cls.count())
                 print(
-                    f"Rank {self.rank}: {cuda.Device.count()} GPUs ("
-                    + ", ".join([cuda.Device(i).name() for i in range(Ngpus)])
+                    f"Rank {self.rank}: {ngpus} GPUs ("
+                    + ", ".join([device_cls(i).name() for i in range(ngpus)])
                     + ")"
                 )
             self.gpu_initialized = True
@@ -85,4 +94,4 @@ class GPUInterface(object):
         except Exception as e:
             self.gpu_initialized = False
             print(f"\nException loading GPU encountered on rank {rank}...")
-            print(repr(e), rank=self.rank)
+            print(f"Rank {self.rank}: {e!r}")

--- a/bayeseor/matrices/build.py
+++ b/bayeseor/matrices/build.py
@@ -720,12 +720,6 @@ class BuildMatrices():
 
                 # Load prerequisite matrix into
                 # prerequisite_matrices_dictionary
-                if matrix_available == 1:
-                    file_extension = ".h5"
-                elif matrix_available == 2:
-                    file_extension = ".npz"
-                else:
-                    file_extension = ".h5"
                 if self.verbose:
                     start = time.time()
                 data = self.read_data(child_matrix)
@@ -1102,7 +1096,7 @@ class BuildMatrices():
 
         """
         matrix_name = "multi_chan_nudft"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1181,7 +1175,7 @@ class BuildMatrices():
 
         """
         matrix_name = "multi_chan_beam"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1293,7 +1287,7 @@ class BuildMatrices():
 
         """
         matrix_name = "nuidft_array"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1366,7 +1360,7 @@ class BuildMatrices():
 
         """
         matrix_name = "multi_chan_nuidft_fg"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1413,7 +1407,7 @@ class BuildMatrices():
         """
         # FIXME: add support for the SHG uv-plane (issue #50)
         matrix_name = "nuidft_array_sh"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1431,7 +1425,9 @@ class BuildMatrices():
 
         nuidft_array_sh_block = IDFT_Array_IDFT_2D_ZM_SH(
             self.nu_sh, self.nv_sh,
-            sampled_lm_coords_radians
+            sampled_lm_coords_radians,
+            delta_u_irad=self.du_eor,
+            delta_v_irad=self.dv_eor,
         )
         nuidft_array_sh_block *= self.Fprime_normalization_eor / (self.nu * self.nv)
         nuidft_array_sh = self.sd_block_diag(
@@ -1486,7 +1482,7 @@ class BuildMatrices():
         """
         # FIXME: add support for the SHG uv-plane (issue #50)
         matrix_name = "idft_array_1d_sh"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1646,7 +1642,7 @@ class BuildMatrices():
 
         """
         matrix_name = "gridding_matrix_vo2co"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1694,7 +1690,7 @@ class BuildMatrices():
 
         """
         matrix_name = "gridding_matrix_vo2co_fg"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -1892,7 +1888,7 @@ class BuildMatrices():
         # this might change in the future if we add a kwarg for writing out
         # intermediate matrices to disk (e.g. the dense blocks that comprise
         # Fprime).
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -2030,7 +2026,7 @@ class BuildMatrices():
 
         """
         matrix_name = "Ninv"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -2103,7 +2099,7 @@ class BuildMatrices():
 
         """
         matrix_name = "N"
-        pmd = self.load_prerequisites(matrix_name)
+        self.load_prerequisites(matrix_name)
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
@@ -2231,9 +2227,8 @@ class BuildMatrices():
                         sky_inds = slice(
                             i_f*self.hpx.npix_fov, (i_f + 1)*self.hpx.npix_fov
                         )
-                        inds = [vis_inds, sky_inds]
                         T[time_inds][vis_inds] = np.dot(
-                            pmd["Finv"][time_inds][*inds].toarray(),
+                            pmd["Finv"][time_inds][vis_inds, sky_inds].toarray(),
                             pmd["Fprime_Fz"][sky_inds]
                         )
         if self.verbose:

--- a/bayeseor/matrices/build.py
+++ b/bayeseor/matrices/build.py
@@ -1,5 +1,5 @@
 import numpy as np
-from subprocess import os
+import os
 import shutil
 import time
 import h5py
@@ -7,7 +7,8 @@ from scipy.linalg import block_diag
 from scipy import sparse
 from scipy.signal import windows
 from pathlib import Path
-from astropy.constants import c
+from astropy import constants as const
+from typing import Any, cast
 
 from .funcs import (
     nuidft_matrix_2d, idft_matrix_1d,
@@ -32,8 +33,10 @@ DEGREES_PER_MIN = DEGREES_PER_SEC * 60
 try:
     from threadpoolctl import threadpool_info
     NTHREADS = threadpool_info()[0]["num_threads"]
-except:
+except Exception:
     NTHREADS = 1
+
+LIGHT_SPEED_M_PER_S = float(cast(Any, getattr(const, "c")).to_value("m/s"))
 
 
 class BuildMatrices():
@@ -251,7 +254,7 @@ class BuildMatrices():
         beam_type=None,
         beam_center=None,
         achromatic_beam=False,
-        beam_peak_amplitude=1,
+        beam_peak_amplitude=1.0,
         fwhm_deg=None,
         antenna_diameter=None,
         cosfreq=None,
@@ -268,6 +271,19 @@ class BuildMatrices():
         verbose=False
     ):
         # FIXME: add check for required args/kwargs
+        assert nu is not None, "nu must not be None."
+        assert nv is not None, "nv must not be None."
+        assert nu_fg is not None, "nu_fg must not be None."
+        assert nv_fg is not None, "nv_fg must not be None."
+        assert nf is not None, "nf must not be None."
+        assert deta is not None, "deta must not be None."
+        assert du_eor is not None, "du_eor must not be None."
+        assert dv_eor is not None, "dv_eor must not be None."
+        assert du_fg is not None, "du_fg must not be None."
+        assert dv_fg is not None, "dv_fg must not be None."
+        assert f_min is not None, "f_min must not be None."
+        assert df is not None, "df must not be None."
+
         self.nu = nu
         self.nv = nv
         self.nu_fg = nu_fg
@@ -281,8 +297,12 @@ class BuildMatrices():
         self.dt = dt
         self.sigma = sigma
         self.fit_for_monopole = fit_for_monopole
+        self.phasor = phasor
+        self.effective_noise = effective_noise
 
-        self.freqs_hertz = (self.f_min + np.arange(self.nf)*self.df) * 1e6
+        self.freqs_hertz = (
+            self.f_min + np.arange(int(self.nf), dtype=float) * self.df
+        ) * 1e6
 
         self.array_dir = array_save_directory
         self.include_instrumental_effects = include_instrumental_effects
@@ -291,11 +311,16 @@ class BuildMatrices():
         self.verbose = verbose
 
         if self.include_instrumental_effects:
+            assert uvw_array_m is not None, "uvw_array_m must not be None."
+            assert bl_red_array is not None, "bl_red_array must not be None."
+            assert nside is not None, "nside must not be None."
+            assert nt is not None, "nt must not be None."
+            assert jd_center is not None, "jd_center must not be None."
+            self.nt = nt
             self.uvw_array_m = uvw_array_m
             self.nbls = uvw_array_m.shape[1]
             self.bl_red_array = bl_red_array
             self.bl_red_array_vec = bl_red_array.reshape(-1, 1).flatten()
-            self.phasor = phasor
             self.fov_ra_eor = fov_ra_eor
             if fov_dec_eor is None:
                 self.fov_dec_eor = self.fov_ra_eor
@@ -321,7 +346,6 @@ class BuildMatrices():
             self.cosfreq = cosfreq
             self.achromatic_beam = achromatic_beam
             self.beam_ref_freq = beam_ref_freq
-            self.effective_noise = effective_noise
 
             self.hpx = Healpix(
                 fov_ra_eor=self.fov_ra_eor,
@@ -342,6 +366,9 @@ class BuildMatrices():
             )
 
             self.drift_scan = drift_scan
+            self.Finv_normalisation = self.hpx.pixel_area_sr
+        else:
+            self.Finv_normalisation = 1.0
 
         # FG model params
         self.nuv_fg = self.nu_fg*self.nv_fg - (not self.fit_for_monopole)
@@ -375,9 +402,6 @@ class BuildMatrices():
             self.nu_fg * self.nv_fg * self.du_fg * self.dv_fg
         )
 
-        # Finv normalization
-        self.Finv_normalisation = self.hpx.pixel_area_sr
-
         # Dictionary with keys for each parent matrix required to build the
         # full matrix stack and values of list containing names of child
         # matrices required to build each parent matrix
@@ -403,6 +427,30 @@ class BuildMatrices():
             self.matrix_prereqs.update(
                 {"Fprime_Fz": ["Fprime", "Fz"], "T": ["Finv", "Fprime_Fz"]}
             )
+        self.matrix_methods = {
+            "idft_array_1d": self.build_idft_array_1d,
+            "multi_vis_idft_array_1d": self.build_multi_vis_idft_array_1d,
+            "gridding_matrix_vo2co": self.build_gridding_matrix_vo2co,
+            "gridding_matrix_co2vo": self.build_gridding_matrix_co2vo,
+            "idft_array_1d_fg": self.build_idft_array_1d_fg,
+            "gridding_matrix_vo2co_fg": self.build_gridding_matrix_vo2co_fg,
+            "Fz": self.build_Fz,
+            "nuidft_array": self.build_nuidft_array,
+            "multi_chan_nuidft": self.build_multi_chan_nuidft,
+            "multi_chan_nuidft_fg": self.build_multi_chan_nuidft_fg,
+            "Fprime": self.build_Fprime,
+            "multi_chan_nudft": self.build_multi_chan_nudft,
+            "multi_chan_beam": self.build_multi_chan_beam,
+            "Finv": self.build_Finv,
+            "Fprime_Fz": self.build_Fprime_Fz,
+            "Finv_Fprime": self.build_Finv_Fprime,
+            "T": self.build_T,
+            "N": self.build_N,
+            "Ninv": self.build_Ninv,
+            "Ninv_T": self.build_Ninv_T,
+            "T_Ninv_T": self.build_T_Ninv_T,
+            "block_T_Ninv_T": self.build_block_T_Ninv_T,
+        }
         if self.phasor is not None:
             self.matrix_prereqs.update(
                 {"Finv": ["phasor_matrix"] + self.matrix_prereqs["Finv"]}
@@ -431,31 +479,6 @@ class BuildMatrices():
             self.matrix_methods.update(
                 {"taper_matrix": self.build_taper_matrix}
             )
-
-        self.matrix_methods = {
-            "idft_array_1d": self.build_idft_array_1d,
-            "multi_vis_idft_array_1d": self.build_multi_vis_idft_array_1d,
-            "gridding_matrix_vo2co": self.build_gridding_matrix_vo2co,
-            "gridding_matrix_co2vo": self.build_gridding_matrix_co2vo,
-            "idft_array_1d_fg": self.build_idft_array_1d_fg,
-            "gridding_matrix_vo2co_fg": self.build_gridding_matrix_vo2co_fg,
-            "Fz": self.build_Fz,
-            "nuidft_array": self.build_nuidft_array,
-            "multi_chan_nuidft": self.build_multi_chan_nuidft,
-            "multi_chan_nuidft_fg": self.build_multi_chan_nuidft_fg,
-            "Fprime": self.build_Fprime,
-            "multi_chan_nudft": self.build_multi_chan_nudft,
-            "multi_chan_beam": self.build_multi_chan_beam,
-            "Finv": self.build_Finv,
-            "Fprime_Fz": self.build_Fprime_Fz,
-            "Finv_Fprime": self.build_Finv_Fprime,
-            "T": self.build_T,
-            "N": self.build_N,
-            "Ninv": self.build_Ninv,
-            "Ninv_T": self.build_Ninv_T,
-            "T_Ninv_T": self.build_T_Ninv_T,
-            "block_T_Ninv_T": self.build_block_T_Ninv_T,
-        }
 
     def check_for_prerequisites(self, parent_matrix):
         """
@@ -1078,7 +1101,7 @@ class BuildMatrices():
         sampled_uvw_coords_m = self.uvw_array_m.copy()
         # Convert uv-coordinates from meters to wavelengths per frequency
         sampled_uvw_coords_wavelengths = np.array([
-            sampled_uvw_coords_m / (c.to("m/s").value / freq)
+            sampled_uvw_coords_m / (LIGHT_SPEED_M_PER_S / freq)
             for freq in self.freqs_hertz
         ])
         if not self.drift_scan:
@@ -1753,7 +1776,7 @@ class BuildMatrices():
         inst_uvw_m = self.uvw_array_m.copy()
         # Convert from meters to inverse radians per frequency
         inst_uvw_irad = [
-            inst_uvw_m / (c.to("m/s").value / freq)
+            inst_uvw_m / (LIGHT_SPEED_M_PER_S / freq)
             for freq in self.freqs_hertz
         ]
         # Shape (nf, nt, nbls, 3)

--- a/bayeseor/matrices/build.py
+++ b/bayeseor/matrices/build.py
@@ -656,7 +656,7 @@ class BuildMatrices():
 
         """
         with h5py.File(file_path, "r") as hf:
-            data = hf[dataset_name][:]
+            data = cast(Any, hf[dataset_name])[:]
         return data
 
     def read_data_from_npz(self, file_path):
@@ -1030,10 +1030,16 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
-        taper = windows.get_window(self.taper_func, self.nf)
-        nbls = self.uvw_array_m.shape[1]
-        taper = np.repeat(taper[None, :], nbls, axis=0).flatten(order="F")
-        taper = np.tile(taper, self.nt)
+        assert self.taper_func is not None, "taper_func must not be None."
+        assert self.uvw_array_m is not None, "uvw_array_m must not be None."
+        assert self.nt is not None, "nt must not be None."
+        taper = np.asarray(
+            windows.get_window(self.taper_func, int(self.nf)),
+            dtype=float,
+        )
+        nbls = int(self.uvw_array_m.shape[1])
+        taper = np.repeat(taper[np.newaxis, :], nbls, axis=0).flatten(order="F")
+        taper = np.tile(taper, int(self.nt))
         if self.use_sparse_matrices:
             taper_matrix = sparse.diags(taper)
         else:
@@ -1065,10 +1071,12 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.phasor is not None, "phasor must not be None."
+        phasor = np.asarray(self.phasor, dtype=complex)
         if self.use_sparse_matrices:
-            phasor_matrix = sparse.diags(self.phasor)
+            phasor_matrix = sparse.diags(phasor)
         else:
-            phasor_matrix = np.diag(self.phasor)
+            phasor_matrix = np.diag(phasor)
         if self.verbose:
             print(f"Time taken: {time.time() - start}")
         self.output_data(phasor_matrix, matrix_name)
@@ -1098,6 +1106,12 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.uvw_array_m is not None, "uvw_array_m must not be None."
+        assert self.hpx is not None, "hpx must not be None."
+        assert self.nt is not None, "nt must not be None."
+        nf = int(self.nf)
+        nt = int(self.nt)
+        hpx_jds = np.asarray(self.hpx.jds, dtype=float)
         sampled_uvw_coords_m = self.uvw_array_m.copy()
         # Convert uv-coordinates from meters to wavelengths per frequency
         sampled_uvw_coords_wavelengths = np.array([
@@ -1108,7 +1122,7 @@ class BuildMatrices():
             # Used if self.drift_scan = False
             # Get (l, m, n) coordinates from Healpix object
             ls_rad, ms_rad, ns_rad = self.hpx.calc_lmn_from_radec(
-                self.hpx.jds[self.nt//2],
+                float(hpx_jds[nt // 2]),
                 self.hpx.ra_fg,
                 self.hpx.dec_fg,
                 radec_offset=self.beam_center
@@ -1120,7 +1134,7 @@ class BuildMatrices():
                     sampled_lmn_coords_radians,
                     sampled_uvw_coords_wavelengths[i_f, 0].reshape(-1, 3)
                 )
-                for i_f in range(self.nf)
+                for i_f in range(nf)
             ])
         else:
             # This will be used if a drift scan primary beam is included in
@@ -1130,7 +1144,7 @@ class BuildMatrices():
                     nuDFT_Array_DFT_2D_v2d0(
                         np.vstack(
                             self.hpx.calc_lmn_from_radec(
-                                self.hpx.jds[i_t],
+                                float(hpx_jds[i_t]),
                                 self.hpx.ra_fg,
                                 self.hpx.dec_fg,
                                 radec_offset=self.beam_center
@@ -1138,9 +1152,9 @@ class BuildMatrices():
                         ).T,
                         sampled_uvw_coords_wavelengths[i_f, i_t].reshape(-1, 3)
                     )
-                    for i_f in range(self.nf)
+                    for i_f in range(nf)
                 ])
-                for i_t in range(self.nt)
+                for i_t in range(nt)
             ])
 
         # Multiply by sky model pixel area to get the units of the
@@ -1171,7 +1185,12 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.hpx is not None, "hpx must not be None."
+        assert self.nt is not None, "nt must not be None."
+        nt = int(self.nt)
+        hpx_jds = np.asarray(self.hpx.jds, dtype=float)
         if self.achromatic_beam:
+            assert self.beam_ref_freq is not None, "beam_ref_freq must not be None."
             freq_array = np.ones_like(self.freqs_hertz) * self.beam_ref_freq
             freq_array *= 1e6  # MHz --> Hz
         else:
@@ -1181,7 +1200,7 @@ class BuildMatrices():
                 np.diag(
                     self.hpx.get_beam_vals(
                         *self.hpx.calc_lmn_from_radec(
-                            self.hpx.jds[self.nt//2],
+                            float(hpx_jds[nt // 2]),
                             self.hpx.ra_fg,
                             self.hpx.dec_fg,
                             radec_offset=self.beam_center,
@@ -1201,7 +1220,7 @@ class BuildMatrices():
                     self.sd_diags(
                         self.hpx.get_beam_vals(
                             *self.hpx.calc_lmn_from_radec(
-                                self.hpx.jds[i_t],
+                                float(hpx_jds[i_t]),
                                 self.hpx.ra_fg,
                                 self.hpx.dec_fg,
                                 radec_offset=self.beam_center,
@@ -1212,7 +1231,7 @@ class BuildMatrices():
                     )
                     for freq in freq_array
                 ])
-                for i_t in range(self.nt)
+                for i_t in range(nt)
             ])
 
         if self.verbose:
@@ -1278,9 +1297,13 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.hpx is not None, "hpx must not be None."
+        assert self.nt is not None, "nt must not be None."
+        nt = int(self.nt)
+        hpx_jds = np.asarray(self.hpx.jds, dtype=float)
         # Get (l, m) coordinates from Healpix object
         ls_rad, ms_rad, _ = self.hpx.calc_lmn_from_radec(
-            self.hpx.jds[self.nt//2],
+            float(hpx_jds[nt // 2]),
             self.hpx.ra_eor,
             self.hpx.dec_eor
         )
@@ -1347,8 +1370,12 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.hpx is not None, "hpx must not be None."
+        assert self.nt is not None, "nt must not be None."
+        nt = int(self.nt)
+        hpx_jds = np.asarray(self.hpx.jds, dtype=float)
         ls_rad, ms_rad, _ = self.hpx.calc_lmn_from_radec(
-            self.hpx.jds[self.nt//2],
+            float(hpx_jds[nt // 2]),
             self.hpx.ra_fg,
             self.hpx.dec_fg
         )
@@ -1390,9 +1417,15 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.hpx is not None, "hpx must not be None."
+        assert self.nt is not None, "nt must not be None."
+        nt = int(self.nt)
+        hpx_jds = np.asarray(self.hpx.jds, dtype=float)
         # Get (l, m) coordinates from Healpix object
         ls_rad, ms_rad, _ = self.hpx.calc_lmn_from_radec(
-            self.hpx.jds[self.nt//2]
+            float(hpx_jds[nt // 2]),
+            self.hpx.ra_fg,
+            self.hpx.dec_fg,
         )
         sampled_lm_coords_radians = np.vstack((ls_rad, ms_rad)).T
 
@@ -1400,7 +1433,7 @@ class BuildMatrices():
             self.nu_sh, self.nv_sh,
             sampled_lm_coords_radians
         )
-        nuidft_array_sh_block *= self.Fprime_normalization / (self.nu*self.nv)
+        nuidft_array_sh_block *= self.Fprime_normalization_eor / (self.nu * self.nv)
         nuidft_array_sh = self.sd_block_diag(
             [nuidft_array_sh_block for i in range(self.nf)]
         )
@@ -1457,18 +1490,20 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.nu_sh is not None, "nu_sh must not be None."
+        assert self.nv_sh is not None, "nv_sh must not be None."
         idft_array_1d_sh_block = idft_array_idft_1d_sh(
             self.nf,
             self.neta,
             self.nq_sh,
             self.npl_sh,
             fit_for_shg_amps=self.fit_for_shg_amps,
-            nu_min_MHz=self.f_min,
-            channel_width_MHz=self.df,
-            beta=self.beta
+            f_min=self.f_min,
+            df=self.df,
+            beta=cast(Any, self.beta),
         )
         idft_array_1d_sh_block *= self.Fz_normalization * self.neta
-        nuv_sh = self.nu_sh*self.nv_sh - 1
+        nuv_sh = self.nu_sh * self.nv_sh - 1
         idft_array_1d_sh = self.sd_block_diag(
             [idft_array_1d_sh_block for _ in range(nuv_sh)]
         )
@@ -1546,8 +1581,10 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.neta is not None, "neta must not be None."
+        neta = int(self.neta)
         eta0_to_frequency = np.ones((self.nf, 1), dtype=complex)
-        eta0_to_frequency *= self.deta * self.neta
+        eta0_to_frequency *= self.deta * neta
         neta0_blocks = self.nuv_fg - self.fit_for_monopole
         idft_array_1d_eta0 = self.sd_block_diag(
             [eta0_to_frequency for _ in range(neta0_blocks)]
@@ -1556,9 +1593,9 @@ class BuildMatrices():
         if self.nq > 0:
             lssm_basis_vecs = build_lssm_basis_vectors(
                 self.nf, nq=self.nq, npl=self.npl, f_min=self.f_min,
-                df=self.df, beta=self.beta, verbose=self.verbose
+                df=self.df, beta=cast(Any, self.beta), verbose=self.verbose
             )
-            lssm_basis_vecs *= self.deta * self.neta
+            lssm_basis_vecs *= self.deta * neta
             lssm_array = self.sd_block_diag(
                 [lssm_basis_vecs for _ in range(neta0_blocks)]
             )
@@ -1568,11 +1605,11 @@ class BuildMatrices():
         if self.fit_for_monopole:
             idft_array_1d_mp = idft_matrix_1d(
                 self.nf, self.neta, nq=self.nq, npl=self.npl,
-                f_min=self.f_min, df=self.df, beta=self.beta
+                f_min=self.f_min, df=self.df, beta=cast(Any, self.beta)
             )
             idft_array_1d_mp *= self.deta
-            idft_array_1d_mp[:, self.neta//2] *= self.neta
-            idft_array_1d_mp[:, self.neta:] *= self.neta
+            idft_array_1d_mp[:, neta // 2] *= neta
+            idft_array_1d_mp[:, neta:] *= neta
             idft_array_1d_fg = self.sd_block_diag(
                 [idft_array_1d_fg, idft_array_1d_mp]
             )
@@ -1732,6 +1769,9 @@ class BuildMatrices():
         # eta=0 is not included in the EoR model, so it's lumped in with
         # the foreground model.
         nuv_fg = self.nu_fg*self.nv_fg - (not self.fit_for_monopole)
+        assert self.nt is not None, "nt must not be None."
+        assert self.hpx is not None, "hpx must not be None."
+        nt = int(self.nt)
         # FIXME: add support for the SHG uv-plane (issue #50)
         # if self.use_shg:
         #     nuv_sh = self.nu_sh*self.nv_sh - 1
@@ -1739,7 +1779,7 @@ class BuildMatrices():
         Finv_Fprime_shape = [
             # Measurement space axis
             # Number of visibilities
-            self.nbls * self.nt * self.nf,
+            self.nbls * nt * self.nf,
             # Combined EoR + FG model (u, v, f) cube axis
             # Number of EoR model parameters
             nuv_eor * self.nf
@@ -1761,7 +1801,7 @@ class BuildMatrices():
                 return_azza=True,
                 radec_offset=self.beam_center,
             )
-            for i_t in range(self.nt)
+            for i_t in range(nt)
         ]
         # Shape (nt, nax, npix)
         # nax index mapping:
@@ -1797,7 +1837,7 @@ class BuildMatrices():
         model_uv_eor_irad = np.vstack((model_us_eor_irad, model_vs_eor_irad))
         nuidft_uv_to_lm_eor = build_nudft_array(
             model_uv_eor_irad,
-            model_lmnazza_rad[self.nt//2, :2, self.hpx.eor_to_fg_pix].T,
+            model_lmnazza_rad[nt // 2, :2, self.hpx.eor_to_fg_pix].T,
             sign=-1
         )
         # FIXME: Fprime normalization no longer needs to include nu*nv norm
@@ -1820,7 +1860,7 @@ class BuildMatrices():
         model_uv_fg_irad = np.vstack((model_us_fg_irad, model_vs_fg_irad))
         nuidft_uv_to_lm_fg = build_nudft_array(
             model_uv_fg_irad,
-            model_lmnazza_rad[self.nt//2, :2],
+            model_lmnazza_rad[nt // 2, :2],
             sign=-1
         )
         # FIXME: Fprime normalization no longer needs to include nu*nv norm
@@ -1871,7 +1911,7 @@ class BuildMatrices():
             #         self.nf*(nuv_eor + nuv_fg) + i_f*?,
             #         self.nf*(nuv_eor + nuv_fg) + (i_f + 1)*?
             #     )
-            for i_t in range(self.nt):
+            for i_t in range(nt):
                 vis_inds = slice(
                     i_t*self.nf*self.nbls + i_f*self.nbls,
                     i_t*self.nf*self.nbls + (i_f + 1)*self.nbls
@@ -1888,9 +1928,9 @@ class BuildMatrices():
                     # For modelling phased observations, the beam is always
                     # phased to the center of the model FoV.  The (l, m, n)
                     # coordinates in this case are independent of time.
-                    lmn_rad = model_lmnazza_rad[self.nt//2, :3]
-                    az_rad = model_lmnazza_rad[self.nt//2, 3]
-                    za_rad = model_lmnazza_rad[self.nt//2, 4]
+                    lmn_rad = model_lmnazza_rad[nt // 2, :3]
+                    az_rad = model_lmnazza_rad[nt // 2, 3]
+                    za_rad = model_lmnazza_rad[nt // 2, 4]
 
                 # NUDFT matrix for image space (l, m, n) to measurement
                 # space (u, v, w) sampled by the instrument
@@ -1994,7 +2034,9 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.sigma is not None, "sigma must not be None."
         if self.include_instrumental_effects:
+            assert self.nt is not None, "nt must not be None."
             if not self.drift_scan:
                 # This array is channel_ordered and the covariance
                 # matrix assumes a channel_ordered data set
@@ -2065,7 +2107,9 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.sigma is not None, "sigma must not be None."
         if self.include_instrumental_effects:
+            assert self.nt is not None, "nt must not be None."
             if not self.drift_scan:
                 # This array is channel_ordered and the covariance
                 # matrix assumes a channel_ordered data set
@@ -2145,6 +2189,8 @@ class BuildMatrices():
         if self.verbose:
             start = time.time()
             print("Performing matrix algebra")
+        assert self.nt is not None, "nt must not be None."
+        nt = int(self.nt)
         if self.Finv_Fprime:
             if self.verbose:
                 print("Constructing T = Finv_Fprime * Fz")
@@ -2176,7 +2222,7 @@ class BuildMatrices():
                     (pmd["Finv"].shape[0], pmd["Fprime_Fz"].shape[1]),
                     dtype=complex
                 )
-                for i_t in range(self.nt):
+                for i_t in range(nt):
                     time_inds = slice(
                         i_t*self.nbls*self.nf, (i_t + 1)*self.nbls*self.nf
                     )

--- a/bayeseor/matrices/funcs.py
+++ b/bayeseor/matrices/funcs.py
@@ -1,5 +1,5 @@
-from numpy import *  # don't know if this will be an issue
-import os  # can be removed after astropy_healpix fixes
+from collections.abc import Sequence
+
 import numpy as np
 from scipy import sparse
 
@@ -307,7 +307,8 @@ def nuidft_matrix_2d(nu, nv, du, dv, l_vec, m_vec, exclude_mean=True):
 # FIXME: IDFT_Array_IDFT_2D_ZM_SH needs to be updated to support the
 # subharmonic grid (see BayesEoR issue #50)
 def IDFT_Array_IDFT_2D_ZM_SH(
-        nu_sh, nv_sh, sampled_lm_coords_radians, spacing='linear'):
+        nu_sh, nv_sh, sampled_lm_coords_radians, spacing='linear',
+        delta_u_irad=None, delta_v_irad=None):
     """
     Generates a non-uniform (might want to update the function name)
     inverse DFT matrix that goes from subharmonic grid (SHG) model (u, v) to
@@ -332,6 +333,12 @@ def IDFT_Array_IDFT_2D_ZM_SH(
         SHG modes is the coarse grid spacing `delta_u_irad` divided by the
         number of SHG modes `nu_sh`.  If log, the SHG modes are determined via
         `np.logspace`.
+    delta_u_irad : float, optional
+        Coarse-grid spacing along the u-axis in inverse radians. Required for
+        SHG spacing calculations.
+    delta_v_irad : float, optional
+        Coarse-grid spacing along the v-axis in inverse radians. Required for
+        SHG spacing calculations.
 
     Returns
     -------
@@ -349,15 +356,17 @@ def IDFT_Array_IDFT_2D_ZM_SH(
     # linear spacing and will need to be reworked if using a log spacing.
     # This also needs to be updated to account for a FoV which differs
     # along the l and m axes.
+    assert delta_u_irad is not None, "delta_u_irad must not be None."
+    assert delta_v_irad is not None, "delta_v_irad must not be None."
     if spacing == 'linear':
         u_vec, v_vec = Produce_Coordinate_Arrays_ZM_SH(nu_sh, nv_sh)
-        du_sh = p.delta_u_irad / nu_sh
-        dv_sh = p.delta_v_irad / nv_sh
+        du_sh = delta_u_irad / nu_sh
+        dv_sh = delta_v_irad / nv_sh
         u_vec = u_vec.astype('float') * du_sh
         v_vec = v_vec.astype('float') * dv_sh
     else:
-        max_u_sh = p.delta_u_irad
-        max_v_sh = p.delta_v_irad
+        max_u_sh = delta_u_irad
+        max_v_sh = delta_v_irad
         min_u_sh = 1 / 2  # horizon to horizon period in l-units
         min_v_sh = 1 / 2  # horizon to horizon period in m-units
         u_sh = np.logspace(
@@ -386,7 +395,13 @@ def IDFT_Array_IDFT_2D_ZM_SH(
 
 # Fz functions
 def build_lssm_basis_vectors(
-    nf, nq=2, npl=0, f_min=159.0, df=0.2, beta=2.63, verbose=False
+    nf,
+    nq=2,
+    npl=0,
+    f_min=159.0,
+    df=0.2,
+    beta: float | Sequence[float] | np.ndarray = 2.63,
+    verbose=False,
 ):
     """
     Construct the Large Spectral Scale Model (LSSM) basis vectors.
@@ -421,12 +436,13 @@ def build_lssm_basis_vectors(
     """
     basis_vectors = np.zeros([nq, nf]) + 0j
     freq_array = f_min + np.arange(nf) * df
+    beta_values = np.atleast_1d(np.asarray(beta, dtype=float))
     if nq == 1:
         x = np.arange(nf) - nf/2.
         basis_vectors[0] = x
         if npl == 1:
             m_pl = np.array(
-                [(freq_array[i_f] / f_min)**-beta
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[0] = m_pl
@@ -442,7 +458,7 @@ def build_lssm_basis_vectors(
         basis_vectors[1] = x**2
         if npl == 1:
             m_pl = np.array(
-                [(freq_array[i_f] / f_min)**-beta
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[1] = m_pl
@@ -453,15 +469,15 @@ def build_lssm_basis_vectors(
                 print('beta = ', beta, '\n')
         if npl == 2:
             m_pl1 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[0]
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[0] = m_pl1
             if verbose:
                 print('\nLinear LW mode replaced with power-law model')
-                print('beta1 = ', beta[0], '\n')
+                print('beta1 = ', beta_values[0], '\n')
             m_pl2 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[1]
+                [(freq_array[i_f] / f_min)**-float(beta_values[1])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[1] = m_pl2
@@ -469,16 +485,16 @@ def build_lssm_basis_vectors(
                 print('\nQuadratic LW mode replaced with power-law model')
                 print('f_min = ', f_min)
                 print('df = ', df)
-                print('beta2 = ', beta[1], '\n')
+                print('beta2 = ', beta_values[1], '\n')
 
     if nq == 3:
         x = np.arange(nf) - nf/2.
         basis_vectors[0] = x
         basis_vectors[1] = x**2
-        basis_vectors[1] = x**3
+        basis_vectors[2] = x**3
         if npl == 1:
             m_pl = np.array(
-                [(freq_array[i_f] / f_min)**-beta
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[1] = m_pl
@@ -490,15 +506,15 @@ def build_lssm_basis_vectors(
 
         if npl == 2:
             m_pl1 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[0]
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[0] = m_pl1
             if verbose:
                 print('\nLinear LW mode replaced with power-law model')
-                print('beta1 = ', beta[0], '\n')
+                print('beta1 = ', beta_values[0], '\n')
             m_pl2 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[1]
+                [(freq_array[i_f] / f_min)**-float(beta_values[1])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[1] = m_pl2
@@ -506,29 +522,27 @@ def build_lssm_basis_vectors(
                 print('\nQuadratic LW mode replaced with power-law model')
                 print('f_min = ', f_min)
                 print('df = ', df)
-                print('beta2 = ', beta[1], '\n')
+                print('beta2 = ', beta_values[1], '\n')
 
         if npl == 3:
             m_pl1 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[0]
+                [(freq_array[i_f] / f_min)**-float(beta_values[0])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[0] = m_pl1
             if verbose:
                 print('\nLinear LW mode replaced with power-law model')
-                print('beta1 = ', beta[0], '\n')
+                print('beta1 = ', beta_values[0], '\n')
             m_pl2 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[1]
+                [(freq_array[i_f] / f_min)**-float(beta_values[1])
                  for i_f in range(len(freq_array))]
                 )
-            # Potential bug if passing len(beta) == 3
-            # Should this call beta[2] instead of beta[1]?
             basis_vectors[1] = m_pl2
             if verbose:
                 print('\nQuadratic LW mode replaced with power-law model')
-                print('beta2 = ', beta[1], '\n')
+                print('beta2 = ', beta_values[1], '\n')
             m_pl3 = np.array(
-                [(freq_array[i_f] / f_min)**-beta[1]
+                [(freq_array[i_f] / f_min)**-float(beta_values[2])
                  for i_f in range(len(freq_array))]
                 )
             basis_vectors[2] = m_pl3
@@ -536,7 +550,7 @@ def build_lssm_basis_vectors(
                 print('\nCubic LW mode replaced with power-law model')
                 print('f_min = ', f_min)
                 print('df = ', df)
-                print('beta3 = ', beta[2], '\n')
+                print('beta3 = ', beta_values[2], '\n')
 
     if nq == 4:
         basis_vectors[0] = np.arange(nf)
@@ -592,8 +606,13 @@ def idft_matrix_1d(
     idft_array = np.exp(-2.0*np.pi*1j*(i_eta*i_f / nf))
 
     if nq > 0:
+        lssm_npl = 0 if npl is None else npl
+        lssm_f_min = 159.0 if f_min is None else f_min
+        lssm_df = 0.2 if df is None else df
+        lssm_beta = 2.63 if beta is None else beta
         lssm_basis_vectors = build_lssm_basis_vectors(
-            nf, nq=nq, npl=npl, f_min=f_min, df=df, beta=beta
+            nf, nq=nq, npl=lssm_npl, f_min=lssm_f_min, df=lssm_df,
+            beta=lssm_beta
         )
         idft_array = np.hstack(
             (idft_array, lssm_basis_vectors)
@@ -653,11 +672,15 @@ def idft_array_idft_1d_sh(
     idft_array_sh /= nf
 
     if nq_sh > 0:
+        lssm_f_min = 159.0 if f_min is None else f_min
+        lssm_df = 0.2 if df is None else df
+        lssm_beta = 2.63 if beta is None else beta
         # Construct large spectral scale model (LSSM) for the SHG modes
         lssm_sh = build_lssm_basis_vectors(
-            nf, nq=nq_sh, npl=npl_sh, f_min=f_min, df=df, beta=beta
+            nf, nq=nq_sh, npl=npl_sh, f_min=lssm_f_min, df=lssm_df,
+            beta=lssm_beta
         )
-        idft_array_sh = np.hstack([idft_array_sh, lssm_sh.T])
+        idft_array_sh = np.hstack([idft_array_sh, lssm_sh])
 
     return idft_array_sh
 

--- a/bayeseor/model/__init__.py
+++ b/bayeseor/model/__init__.py
@@ -1,4 +1,17 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .healpix import Healpix
+    from .instrument import load_inst_model
+    from .k_cube import (
+        calc_mean_binned_k_vals,
+        generate_k_cube_in_physical_coordinates,
+        generate_k_cube_model_cylindrical_binning,
+        generate_k_cube_model_spherical_binning,
+        mask_k_cube,
+    )
+    from .noise import generate_gaussian_noise
 
 __all__ = [
     "Healpix",

--- a/bayeseor/model/healpix.py
+++ b/bayeseor/model/healpix.py
@@ -3,21 +3,21 @@ Interface for the HEALPix image domain model in BayesEoR.
 """
 
 import numpy as np
-from typing import Literal, Sequence, TypeAlias, overload
+from typing import Any, Literal, Sequence, TypeAlias, cast, overload
 
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike, NDArray
 from astropy_healpix import HEALPix
 from astropy_healpix import healpy as hp
 from astropy.coordinates import\
     EarthLocation, AltAz, ICRS, Angle, SkyCoord
 from astropy.time import Time
+from astropy import constants as const
 import astropy.units as u
-from astropy.constants import c
 from scipy.special import j1
 from pyuvdata import UVBeam
 from pyuvdata import utils as uvutils
 
-c_ms = c.to("m/s").value
+c_ms = float(const.c.to_value(u.m / u.s))  # pyright: ignore
 
 SECS_PER_HOUR = 60 * 60
 SECS_PER_DAY = SECS_PER_HOUR * 24
@@ -153,7 +153,8 @@ class Healpix(HEALPix):
                 self.fov_dec_eor == self.fov_dec_fg
             )
 
-        self.pixel_area_sr = self.pixel_area.to("sr").value
+        pixel_area = cast(Any, self.pixel_area)
+        self.pixel_area_sr = float(pixel_area.to_value(u.sr))
         self.tele_lat, self.tele_lon, self.tele_alt = telescope_latlonalt
         # Set telescope location
         telescope_xyz = uvutils.XYZ_from_LatLonAlt(
@@ -387,11 +388,13 @@ class Healpix(HEALPix):
           issues with the rectangular pixel selections.
 
         """
-        lons, lats = hp.pix2ang(
+        lons_raw, lats_raw = hp.pix2ang(
             self.nside,
-            np.arange(self.npix),
+            np.arange(int(self.npix)),
             lonlat=True
         )
+        lons: FloatArray = np.asarray(lons_raw, dtype=float)
+        lats: FloatArray = np.asarray(lats_raw, dtype=float)
         if simple_za_filter:
             _, _, _, _, za = self.calc_lmn_from_radec(
                 self.jd_center, lons, lats, return_azza=True
@@ -461,8 +464,8 @@ class Healpix(HEALPix):
     def calc_lmn_from_radec(
         self,
         time: float | Time,
-        ra: FloatArray,
-        dec: FloatArray,
+        ra: ArrayLike,
+        dec: ArrayLike,
         return_azza: Literal[False] = False,
         radec_offset: tuple[float, float] | None = None
     ) -> tuple[FloatArray, FloatArray, FloatArray]:
@@ -472,8 +475,8 @@ class Healpix(HEALPix):
     def calc_lmn_from_radec(
         self,
         time: float | Time,
-        ra: FloatArray,
-        dec: FloatArray,
+        ra: ArrayLike,
+        dec: ArrayLike,
         return_azza: Literal[True] = True,
         radec_offset: tuple[float, float] | None = None
     ) -> tuple[FloatArray, FloatArray, FloatArray, FloatArray, FloatArray]:
@@ -482,8 +485,8 @@ class Healpix(HEALPix):
     def calc_lmn_from_radec(
             self,
             time: float | Time,
-            ra: FloatArray,
-            dec: FloatArray,
+            ra: ArrayLike,
+            dec: ArrayLike,
             return_azza: bool = False,
             radec_offset: tuple[float, float] | None = None
     ) -> tuple[FloatArray, FloatArray, FloatArray] | tuple[
@@ -525,16 +528,17 @@ class Healpix(HEALPix):
             time = Time(time, format="jd")
 
         skycoord = SkyCoord(ra*u.deg, dec*u.deg, frame="icrs")
-        altaz = skycoord.transform_to(
+        altaz = cast(Any, skycoord.transform_to(
             AltAz(obstime=time, location=self.telescope_location)
-        )
-        az = altaz.az.rad
-        za = np.pi/2 - altaz.alt.rad
+        ))
+        az: FloatArray = np.asarray(altaz.az.to_value(u.rad), dtype=float)
+        alt: FloatArray = np.asarray(altaz.alt.to_value(u.rad), dtype=float)
+        za: FloatArray = np.pi / 2 - alt
 
         # Convert from (az, za) to (l, m, n)
-        ls = np.sin(za) * np.sin(az)
-        ms = np.sin(za) * np.cos(az)
-        ns = np.cos(za)
+        ls: FloatArray = np.sin(za) * np.sin(az)
+        ms: FloatArray = np.sin(za) * np.cos(az)
+        ns: FloatArray = np.cos(za)
 
         if return_azza:
             return ls, ms, ns, az, za

--- a/bayeseor/model/healpix.py
+++ b/bayeseor/model/healpix.py
@@ -8,8 +8,7 @@ from typing import Any, Literal, Sequence, TypeAlias, cast, overload
 from numpy.typing import ArrayLike, NDArray
 from astropy_healpix import HEALPix
 from astropy_healpix import healpy as hp
-from astropy.coordinates import\
-    EarthLocation, AltAz, ICRS, Angle, SkyCoord
+from astropy.coordinates import EarthLocation, AltAz, ICRS, Angle, SkyCoord
 from astropy.time import Time
 from astropy import constants as const
 import astropy.units as u
@@ -28,12 +27,13 @@ DEGREES_PER_SEC = DEGREES_PER_HOUR * 1 / SECS_PER_HOUR
 HERA_LAT_LON_ALT = (
     -30.72152777777791,  # deg
     21.428305555555557,  # deg
-    1073.0000000093132  # meters
+    1073.0000000093132,  # meters
 )
 
 FloatArray: TypeAlias = NDArray[np.float64]
 IntArray: TypeAlias = NDArray[np.int_]
 BoolArray: TypeAlias = NDArray[np.bool_]
+
 
 class Healpix(HEALPix):
     """
@@ -98,6 +98,7 @@ class Healpix(HEALPix):
         for valid options and more details.  Defaults to 'cubic'.
 
     """
+
     def __init__(
         self,
         fov_ra_eor: float | None = None,
@@ -118,17 +119,14 @@ class Healpix(HEALPix):
         tanh_freq: float | None = None,
         tanh_sl_red: float | None = None,
         pol: str = "xx",
-        freq_interp_kind: str = "cubic"
+        freq_interp_kind: str = "cubic",
     ) -> None:
         # Use HEALPix as parent class to get useful astropy_healpix functions
         super().__init__(nside, frame=ICRS())
 
-        assert fov_ra_eor is not None, \
-            "Missing required keyword argument: fov_ra_eor ."
-        assert jd_center is not None, \
-            "Missing required keyword argument: jd_center."
-        assert nt == 1 or dt is not None, \
-            "If nt > 1, dt must not be None."
+        assert fov_ra_eor is not None, "Missing required keyword argument: fov_ra_eor ."
+        assert jd_center is not None, "Missing required keyword argument: jd_center."
+        assert nt == 1 or dt is not None, "If nt > 1, dt must not be None."
 
         self.fov_ra_eor = fov_ra_eor
         if fov_dec_eor is None:
@@ -141,16 +139,16 @@ class Healpix(HEALPix):
             self.fov_dec_fg = self.fov_dec_eor
             self.fovs_match = True
         else:
-            assert fov_ra_fg >= fov_ra_eor, \
+            assert fov_ra_fg >= fov_ra_eor, (
                 "fov_ra_fg must be greater than or equal to fov_ra_eor."
+            )
             self.fov_ra_fg = fov_ra_fg
             if fov_dec_fg is None:
                 self.fov_dec_fg = self.fov_ra_fg
             else:
                 self.fov_dec_fg = fov_dec_fg
             self.fovs_match = np.logical_and(
-                self.fov_ra_eor == self.fov_ra_fg,
-                self.fov_dec_eor == self.fov_dec_fg
+                self.fov_ra_eor == self.fov_ra_fg, self.fov_dec_eor == self.fov_dec_fg
             )
 
         pixel_area = cast(Any, self.pixel_area)
@@ -158,9 +156,7 @@ class Healpix(HEALPix):
         self.tele_lat, self.tele_lon, self.tele_alt = telescope_latlonalt
         # Set telescope location
         telescope_xyz = uvutils.XYZ_from_LatLonAlt(
-            self.tele_lat * np.pi / 180,
-            self.tele_lon * np.pi / 180,
-            self.tele_alt
+            self.tele_lat * np.pi / 180, self.tele_lon * np.pi / 180, self.tele_alt
         )
         self.telescope_location = EarthLocation.from_geocentric(
             *telescope_xyz, unit="m"
@@ -173,7 +169,7 @@ class Healpix(HEALPix):
             alt=Angle("90d"),
             az=Angle("0d"),
             obstime=t,
-            location=self.telescope_location
+            location=self.telescope_location,
         )
         zen_radec = zen.transform_to(ICRS())
         self.field_center = (zen_radec.ra.deg, zen_radec.dec.deg)
@@ -187,10 +183,7 @@ class Healpix(HEALPix):
             self.time_inds = np.arange(-(self.nt // 2), self.nt // 2)
         # Calculate JD per integration from `jd_center`
         if self.dt is not None:
-            self.jds = (
-                self.jd_center
-                + self.time_inds * self.dt * DAYS_PER_SEC
-            )
+            self.jds = self.jd_center + self.time_inds * self.dt * DAYS_PER_SEC
         else:
             self.jds = np.array([self.jd_center])
         # Calculate pointing center per integration
@@ -201,7 +194,7 @@ class Healpix(HEALPix):
                 alt=Angle("90d"),
                 az=Angle("0d"),
                 obstime=t,
-                location=self.telescope_location
+                location=self.telescope_location,
             )
             zen_radec = zen.transform_to(ICRS())
             self.pointing_centers.append((zen_radec.ra.deg, zen_radec.dec.deg))
@@ -212,11 +205,16 @@ class Healpix(HEALPix):
             if "." not in beam_type:
                 beam_type = beam_type.lower()
                 allowed_types = [
-                    "uniform", "gaussian", "airy", "gausscosine", "taperairy",
-                    "tanhairy"
+                    "uniform",
+                    "gaussian",
+                    "airy",
+                    "gausscosine",
+                    "taperairy",
+                    "tanhairy",
                 ]
-                assert beam_type in allowed_types, \
+                assert beam_type in allowed_types, (
                     f"Only {', '.join(allowed_types)} beams are supported."
+                )
                 self.beam_type = beam_type
                 self.uvb = None
             else:
@@ -242,29 +240,30 @@ class Healpix(HEALPix):
 
         if beam_type == "gaussian":
             required_params = [diam, fwhm_deg]
-            assert self._check_required_params(required_params, all_req=False),\
-                "If using a Gaussian beam, must pass either " \
-                "'fwhm_deg' or 'diam'."
+            assert self._check_required_params(required_params, all_req=False), (
+                "If using a Gaussian beam, must pass either 'fwhm_deg' or 'diam'."
+            )
         elif beam_type == "airy":
             required_params = [diam, fwhm_deg]
-            assert self._check_required_params(required_params, all_req=False),\
-                "If using an Airy beam, must pass either " \
-                "'fwhm_deg' or 'diam'."
+            assert self._check_required_params(required_params, all_req=False), (
+                "If using an Airy beam, must pass either 'fwhm_deg' or 'diam'."
+            )
         elif beam_type == "taperairy":
             required_params = [diam, fwhm_deg]
-            assert self._check_required_params(required_params), \
-                "If using a taperairy beam, must pass " \
-                "'diam' and 'fwhm_deg'."
+            assert self._check_required_params(required_params), (
+                "If using a taperairy beam, must pass 'diam' and 'fwhm_deg'."
+            )
         elif beam_type == "gausscosine":
             required_params = [fwhm_deg, cosfreq]
-            assert self._check_required_params(required_params), \
-                "If using a gausscosine beam, must pass " \
-                "'fwhm_deg' and 'cosfreq'."
+            assert self._check_required_params(required_params), (
+                "If using a gausscosine beam, must pass 'fwhm_deg' and 'cosfreq'."
+            )
         elif beam_type == "tanhairy":
             required_params = [diam, tanh_freq, tanh_sl_red]
-            assert self._check_required_params(required_params), \
-                "If using a tanhairy beam, must pass " \
+            assert self._check_required_params(required_params), (
+                "If using a tanhairy beam, must pass "
                 "'diam', 'tanh_freq', and 'tanh_sl_red'."
+            )
         self.fwhm_deg = fwhm_deg
         self.diam = diam
         self.cosfreq = cosfreq
@@ -274,8 +273,10 @@ class Healpix(HEALPix):
         # Pixel filters
         self.simple_za_filter = simple_za_filter
         pix_eor, ra_eor, dec_eor = self.get_pixel_filter(
-            self.fov_ra_eor, self.fov_dec_eor, return_radec=True,
-            simple_za_filter=self.simple_za_filter
+            self.fov_ra_eor,
+            self.fov_dec_eor,
+            return_radec=True,
+            simple_za_filter=self.simple_za_filter,
         )
         self.pix_eor = pix_eor
         self.ra_eor = ra_eor
@@ -289,8 +290,10 @@ class Healpix(HEALPix):
             self.npix_fov_fg = self.pix_fg.size
         else:
             pix_fg, ra_fg, dec_fg = self.get_pixel_filter(
-                self.fov_ra_fg, self.fov_dec_fg, return_radec=True,
-                simple_za_filter=self.simple_za_filter
+                self.fov_ra_fg,
+                self.fov_dec_fg,
+                return_radec=True,
+                simple_za_filter=self.simple_za_filter,
             )
             self.pix_fg = pix_fg
             self.npix_fov_fg = self.pix_fg.size
@@ -315,9 +318,8 @@ class Healpix(HEALPix):
         fov_dec: float,
         return_radec: Literal[False] = False,
         inverse: bool = False,
-        simple_za_filter: bool = True
-    ) -> IntArray:
-        ...
+        simple_za_filter: bool = True,
+    ) -> IntArray: ...
 
     @overload
     def get_pixel_filter(
@@ -326,9 +328,8 @@ class Healpix(HEALPix):
         fov_dec: float,
         return_radec: Literal[True] = True,
         inverse: bool = False,
-        simple_za_filter: bool = True
-    ) -> tuple[IntArray, FloatArray, FloatArray]:
-        ...
+        simple_za_filter: bool = True,
+    ) -> tuple[IntArray, FloatArray, FloatArray]: ...
 
     def get_pixel_filter(
         self,
@@ -336,7 +337,7 @@ class Healpix(HEALPix):
         fov_dec: float,
         return_radec: bool = False,
         inverse: bool = False,
-        simple_za_filter: bool = True
+        simple_za_filter: bool = True,
     ) -> IntArray | tuple[IntArray, FloatArray, FloatArray]:
         """
         Return HEALPix pixel indices lying inside an observed region.
@@ -389,9 +390,7 @@ class Healpix(HEALPix):
 
         """
         lons_raw, lats_raw = hp.pix2ang(
-            self.nside,
-            np.arange(int(self.npix)),
-            lonlat=True
+            self.nside, np.arange(int(self.npix)), lonlat=True
         )
         lons: FloatArray = np.asarray(lons_raw, dtype=float)
         lats: FloatArray = np.asarray(lats_raw, dtype=float)
@@ -403,16 +402,16 @@ class Healpix(HEALPix):
             pix = np.where(za <= max_za)[0]
         else:
             thetas = (90 - lats) * np.pi / 180
-            if self.field_center[0] - fov_ra/2 < 0:
+            if self.field_center[0] - fov_ra / 2 < 0:
                 lons[lons > 180] -= 360  # lons in (-180, 180]
             lons_inds = np.logical_and(
-                (lons - self.field_center[0])*np.sin(thetas) >= -fov_ra/2,
-                (lons - self.field_center[0])*np.sin(thetas) <= fov_ra/2,
-                )
+                (lons - self.field_center[0]) * np.sin(thetas) >= -fov_ra / 2,
+                (lons - self.field_center[0]) * np.sin(thetas) <= fov_ra / 2,
+            )
             lats_inds = np.logical_and(
                 lats >= self.field_center[1] - fov_dec / 2,
-                lats <= self.field_center[1] + fov_dec / 2
-                )
+                lats <= self.field_center[1] + fov_dec / 2,
+            )
             pixel_mask: BoolArray = np.logical_and(lons_inds, lats_inds)
             if inverse:
                 pix = np.where(np.logical_not(pixel_mask))[0]
@@ -425,10 +424,7 @@ class Healpix(HEALPix):
             return pix, lons[pix], lats[pix]
 
     def get_extent_ra_dec(
-        self,
-        fov_ra: float,
-        fov_dec: float,
-        fov_fac: float = 1.0
+        self, fov_ra: float, fov_dec: float, fov_fac: float = 1.0
     ) -> tuple[list[float], list[float]]:
         """
         Get the sampled extent of the sky in RA and DEC.
@@ -451,12 +447,12 @@ class Healpix(HEALPix):
 
         """
         range_ra = [
-            self.field_center[0] - fov_fac*fov_ra/2,
-            self.field_center[0] + fov_fac*fov_ra/2
+            self.field_center[0] - fov_fac * fov_ra / 2,
+            self.field_center[0] + fov_fac * fov_ra / 2,
         ]
         range_dec = [
-            self.field_center[1] - fov_fac*fov_dec/2,
-            self.field_center[1] + fov_fac*fov_dec/2
+            self.field_center[1] - fov_fac * fov_dec / 2,
+            self.field_center[1] + fov_fac * fov_dec / 2,
         ]
         return range_ra, range_dec
 
@@ -467,9 +463,8 @@ class Healpix(HEALPix):
         ra: ArrayLike,
         dec: ArrayLike,
         return_azza: Literal[False] = False,
-        radec_offset: tuple[float, float] | None = None
-    ) -> tuple[FloatArray, FloatArray, FloatArray]:
-        ...
+        radec_offset: tuple[float, float] | None = None,
+    ) -> tuple[FloatArray, FloatArray, FloatArray]: ...
 
     @overload
     def calc_lmn_from_radec(
@@ -478,20 +473,20 @@ class Healpix(HEALPix):
         ra: ArrayLike,
         dec: ArrayLike,
         return_azza: Literal[True] = True,
-        radec_offset: tuple[float, float] | None = None
-    ) -> tuple[FloatArray, FloatArray, FloatArray, FloatArray, FloatArray]:
-        ...
+        radec_offset: tuple[float, float] | None = None,
+    ) -> tuple[FloatArray, FloatArray, FloatArray, FloatArray, FloatArray]: ...
 
     def calc_lmn_from_radec(
-            self,
-            time: float | Time,
-            ra: ArrayLike,
-            dec: ArrayLike,
-            return_azza: bool = False,
-            radec_offset: tuple[float, float] | None = None
-    ) -> tuple[FloatArray, FloatArray, FloatArray] | tuple[
-        FloatArray, FloatArray, FloatArray, FloatArray, FloatArray
-    ]:
+        self,
+        time: float | Time,
+        ra: ArrayLike,
+        dec: ArrayLike,
+        return_azza: bool = False,
+        radec_offset: tuple[float, float] | None = None,
+    ) -> (
+        tuple[FloatArray, FloatArray, FloatArray]
+        | tuple[FloatArray, FloatArray, FloatArray, FloatArray, FloatArray]
+    ):
         """
         Return arrays of (l, m, n) coordinates in radians for all (RA, DEC).
 
@@ -527,10 +522,13 @@ class Healpix(HEALPix):
         if not isinstance(time, Time):
             time = Time(time, format="jd")
 
-        skycoord = SkyCoord(ra*u.deg, dec*u.deg, frame="icrs")
-        altaz = cast(Any, skycoord.transform_to(
-            AltAz(obstime=time, location=self.telescope_location)
-        ))
+        skycoord = SkyCoord(ra * u.deg, dec * u.deg, frame="icrs")
+        altaz = cast(
+            Any,
+            skycoord.transform_to(
+                AltAz(obstime=time, location=self.telescope_location)
+            ),
+        )
         az: FloatArray = np.asarray(altaz.az.to_value(u.rad), dtype=float)
         alt: FloatArray = np.asarray(altaz.alt.to_value(u.rad), dtype=float)
         za: FloatArray = np.pi / 2 - alt
@@ -546,10 +544,7 @@ class Healpix(HEALPix):
             return ls, ms, ns
 
     def get_beam_vals(
-        self,
-        az: FloatArray,
-        za: FloatArray,
-        freq: float | None = None
+        self, az: FloatArray, za: FloatArray, freq: float | None = None
     ) -> FloatArray:
         """
         Get an array of beam values from (az, za) coordinates.
@@ -577,9 +572,7 @@ class Healpix(HEALPix):
 
         elif self.beam_type in ["gaussian", "gausscosine"]:
             if self.fwhm_deg is not None:
-                stddev_rad = np.deg2rad(
-                    self._fwhm_to_stddev(self.fwhm_deg)
-                )
+                stddev_rad = np.deg2rad(self._fwhm_to_stddev(self.fwhm_deg))
             else:
                 assert self.diam is not None
                 assert freq is not None
@@ -606,9 +599,8 @@ class Healpix(HEALPix):
             assert self.diam is not None
             assert freq is not None
             stddev_rad = np.deg2rad(self._fwhm_to_stddev(self.fwhm_deg))
-            beam_vals = (
-                self._airy_disk(za, self.diam, freq)
-                * self._gaussian_za(za, stddev_rad, self.peak_amp)
+            beam_vals = self._airy_disk(za, self.diam, freq) * self._gaussian_za(
+                za, stddev_rad, self.peak_amp
             )
 
         elif self.beam_type == "tanhairy":
@@ -616,17 +608,15 @@ class Healpix(HEALPix):
             assert freq is not None
             assert self.tanh_freq is not None
             assert self.tanh_sl_red is not None
-            beam_vals = (
-                self._airy_disk(za, self.diam, freq)
-                * self._tanh_taper(za, self.tanh_freq, self.tanh_sl_red)
+            beam_vals = self._airy_disk(za, self.diam, freq) * self._tanh_taper(
+                za, self.tanh_freq, self.tanh_sl_red
             )
 
         elif self.beam_type == "uvbeam":
             assert self.uvb is not None
             assert freq is not None
             beam_vals, _ = self.uvb.interp(
-                az_array=az, za_array=za, freq_array=np.array([freq]),
-                reuse_spline=True
+                az_array=az, za_array=za, freq_array=np.array([freq]), reuse_spline=True
             )
             beam_vals = beam_vals[0, 0, 0, 0].real
         else:
@@ -653,15 +643,11 @@ class Healpix(HEALPix):
             Array of Gaussian beam amplitudes for each zenith angle in `za`.
 
         """
-        beam_vals = amp * np.exp(-za ** 2 / (2 * sigma ** 2))
+        beam_vals = amp * np.exp(-(za**2) / (2 * sigma**2))
         return beam_vals
 
     def _gausscosine(
-        self,
-        za: FloatArray,
-        sigma: float,
-        amp: float,
-        cosfreq: float
+        self, za: FloatArray, sigma: float, amp: float, cosfreq: float
     ) -> FloatArray:
         """
         Calculate azimuthally symmetric Gaussian * cosine^2 beam amplitudes.
@@ -683,8 +669,8 @@ class Healpix(HEALPix):
             Array of Gaussian beam amplitudes for each zenith angle in `za`.
 
         """
-        beam_vals = amp * np.exp(-za ** 2 / (2 * sigma ** 2))
-        beam_vals *= np.cos(2 * np.pi * za * cosfreq/2)**2
+        beam_vals = amp * np.exp(-(za**2) / (2 * sigma**2))
+        beam_vals *= np.cos(2 * np.pi * za * cosfreq / 2) ** 2
         return beam_vals
 
     def _fwhm_to_stddev(self, fwhm: float) -> float:
@@ -718,22 +704,16 @@ class Healpix(HEALPix):
             Array of Airy disk amplitudes for each zenith angle in `za`.
 
         """
-        xvals = (
-                diam / 2. * np.sin(za)
-                * 2. * np.pi * freq / c_ms
-        )
+        xvals = diam / 2.0 * np.sin(za) * 2.0 * np.pi * freq / c_ms
         beam_vals = np.zeros_like(xvals)
-        nz = xvals != 0.
-        ze = xvals == 0.
-        beam_vals[nz] = 2. * j1(xvals[nz]) / xvals[nz]
-        beam_vals[ze] = 1.
-        return beam_vals ** 2
+        nz = xvals != 0.0
+        ze = xvals == 0.0
+        beam_vals[nz] = 2.0 * j1(xvals[nz]) / xvals[nz]
+        beam_vals[ze] = 1.0
+        return beam_vals**2
 
     def _tanh_taper(
-        self,
-        za: FloatArray,
-        tanh_freq: float,
-        tanh_sl_red: float
+        self, za: FloatArray, tanh_freq: float, tanh_sl_red: float
     ) -> FloatArray:
         """
         Calculate a tanh tapering function.
@@ -819,9 +799,7 @@ class Healpix(HEALPix):
         return sigma
 
     def _check_required_params(
-        self,
-        required_params: Sequence[object | None],
-        all_req: bool = True
+        self, required_params: Sequence[object | None], all_req: bool = True
     ) -> bool:
         """
         Check if params in required_params are not None.

--- a/bayeseor/model/instrument.py
+++ b/bayeseor/model/instrument.py
@@ -3,16 +3,17 @@ from pathlib import Path
 
 from ..utils import load_numpy_dict
 
+
 def load_inst_model(
     inst_model_dir,
     uvw_file="uvw_model.npy",
     red_file="redundancy_model.npy",
     antpairs_file="antpairs.npy",
-    phasor_file="phasor_vector.npy"
+    phasor_file="phasor_vector.npy",
 ):
     """
     Load a BayesEoR instrument model.
-    
+
     The instrument model consists of:
     - (u, v, w) array with shape `(nt, nbls, 3)` where `nt` is the number of
       times and `nbls` is the number of baselines
@@ -63,8 +64,7 @@ def load_inst_model(
 
     if (inst_model_dir / "instrument_model.npy").exists():
         data_dict = np.load(
-            inst_model_dir / "instrument_model.npy",
-            allow_pickle=True
+            inst_model_dir / "instrument_model.npy", allow_pickle=True
         ).item()
         uvw_array_m = data_dict["uvw_model"]
         bl_red_array = data_dict["redundancy_model"]

--- a/bayeseor/model/k_cube.py
+++ b/bayeseor/model/k_cube.py
@@ -3,12 +3,7 @@ from pathlib import Path
 
 
 def generate_k_cube_in_physical_coordinates(
-    nu,
-    nv,
-    neta,
-    ps_box_size_ra_Mpc,
-    ps_box_size_dec_Mpc,
-    ps_box_size_para_Mpc
+    nu, nv, neta, ps_box_size_ra_Mpc, ps_box_size_dec_Mpc, ps_box_size_para_Mpc
 ):
     """
     Generates rectilinear k-space cubes in units of inverse Mpc.
@@ -50,23 +45,23 @@ def generate_k_cube_in_physical_coordinates(
 
     """
     # Generate k_cube pixel coordinates
-    eta_ind_min = -(neta//2)
-    eta_ind_max = neta//2
+    eta_ind_min = -(neta // 2)
+    eta_ind_max = neta // 2
     if neta % 2 == 1:
         # neta is odd
         eta_ind_max += 1
-    z, y, x = np.mgrid[eta_ind_min:eta_ind_max,
-                       -(nv//2):(nv//2)+1,
-                       -(nu//2):(nu//2)+1]
+    z, y, x = np.mgrid[
+        eta_ind_min:eta_ind_max, -(nv // 2) : (nv // 2) + 1, -(nu // 2) : (nu // 2) + 1
+    ]
 
     # Setup k-space arrays
-    deltakx = 2.*np.pi / ps_box_size_ra_Mpc
-    deltaky = 2.*np.pi / ps_box_size_dec_Mpc
-    deltakz = 2.*np.pi / ps_box_size_para_Mpc
+    deltakx = 2.0 * np.pi / ps_box_size_ra_Mpc
+    deltaky = 2.0 * np.pi / ps_box_size_dec_Mpc
+    deltakz = 2.0 * np.pi / ps_box_size_para_Mpc
     k_z = z * deltakz
     k_y = y * deltaky
     k_x = x * deltakx
-    mod_k_physical = (k_z**2. + k_y**2. + k_x**2.)**0.5
+    mod_k_physical = (k_z**2.0 + k_y**2.0 + k_x**2.0) ** 0.5
 
     return mod_k_physical, k_x, k_y, k_z, x, y, z
 
@@ -90,16 +85,16 @@ def mask_k_cube(mod_k):
     neta, nv, nu = mod_k.shape
 
     # Remove the eta=0 mode from the EoR k-cube
-    mod_k = np.delete(mod_k, neta//2, axis=0)
+    mod_k = np.delete(mod_k, neta // 2, axis=0)
 
     # Flatten along k_x then k_y
-    mod_k = mod_k.reshape((neta - 1, nu*nv))
+    mod_k = mod_k.reshape((neta - 1, nu * nv))
 
     # Remove (u, v) = (0, 0)
-    mod_k = np.delete(mod_k, (nu*nv)//2, axis=1)
+    mod_k = np.delete(mod_k, (nu * nv) // 2, axis=1)
 
     # Flattened arrays move first along k_z, then k_x, and lastly k_y
-    mod_k_vo = mod_k.flatten(order='F')
+    mod_k_vo = mod_k.flatten(order="F")
 
     return mod_k_vo
 
@@ -129,7 +124,7 @@ def generate_k_cube_model_spherical_binning(mod_k_vo, ps_box_size_para_Mpc):
 
     """
     modkscaleterm = 1.35
-    deltakpara = 2.*np.pi / ps_box_size_para_Mpc
+    deltakpara = 2.0 * np.pi / ps_box_size_para_Mpc
     binsize = deltakpara * 2.0
 
     numKbins = 50
@@ -139,7 +134,7 @@ def generate_k_cube_model_spherical_binning(mod_k_vo, ps_box_size_para_Mpc):
 
     for m1 in range(1, numKbins, 1):
         binsize = binsize * modkscaleterm
-        modkbins[m1, 0] = modkbins[m1-1, 1]
+        modkbins[m1, 0] = modkbins[m1 - 1, 1]
         modkbins[m1, 1] = modkscaleterm * modkbins[m1, 0]
 
     total_elements = 0
@@ -151,10 +146,9 @@ def generate_k_cube_model_spherical_binning(mod_k_vo, ps_box_size_para_Mpc):
         # explicitly with the quadratic modes, then k_z==0 should be
         # added to the quadratic selector mask
         n_elements = np.sum(
-            np.logical_and.reduce((
-                mod_k_vo > modkbins[i_bin, 0],
-                mod_k_vo <= modkbins[i_bin, 1]
-            ))
+            np.logical_and.reduce(
+                (mod_k_vo > modkbins[i_bin, 0], mod_k_vo <= modkbins[i_bin, 1])
+            )
         )
         if n_elements > 0:
             n_bins += 1
@@ -165,10 +159,12 @@ def generate_k_cube_model_spherical_binning(mod_k_vo, ps_box_size_para_Mpc):
     count = 0
     for i_bin in range(len(modkbins_containing_voxels)):
         relevant_voxels = np.where(
-            np.logical_and.reduce((
-                mod_k_vo > modkbins_containing_voxels[i_bin][0][0],
-                mod_k_vo <= modkbins_containing_voxels[i_bin][0][1]
-            ))
+            np.logical_and.reduce(
+                (
+                    mod_k_vo > modkbins_containing_voxels[i_bin][0][0],
+                    mod_k_vo <= modkbins_containing_voxels[i_bin][0][1],
+                )
+            )
         )
         count += len(relevant_voxels[0])
         k_cube_voxels_in_bin.append(relevant_voxels)
@@ -182,7 +178,7 @@ def calc_mean_binned_k_vals(
     save_k_vals=False,
     clobber=False,
     k_vals_file="k-vals.txt",
-    k_vals_dir="k_vals"
+    k_vals_dir="k_vals",
 ):
     """
     Calculates the mean of all |k| that fall within a k-bin.
@@ -227,12 +223,8 @@ def calc_mean_binned_k_vals(
     if save:
         k_vals_dir.mkdir(parents=True, exist_ok=True)
         np.savetxt(k_vals_dir / k_vals_file, k_vals)
-        np.savetxt(
-            k_vals_dir / k_vals_file.replace(".txt", "-bins.txt"), kbin_edges
-        )
-        np.savetxt(
-            k_vals_dir / k_vals_file.replace(".txt", "-nsamples.txt"), nsamples
-        )
+        np.savetxt(k_vals_dir / k_vals_file.replace(".txt", "-bins.txt"), kbin_edges)
+        np.savetxt(k_vals_dir / k_vals_file.replace(".txt", "-nsamples.txt"), nsamples)
 
     return np.array(k_vals)
 
@@ -243,7 +235,7 @@ def generate_k_cube_model_cylindrical_binning(
     k_y_masked,
     k_x_masked,
     n_k_perp_bins,
-    ps_box_size_para_Mpc
+    ps_box_size_para_Mpc,
 ):
     """
     Generates a set of cylindrical k-space bins from which the 2D power
@@ -282,7 +274,7 @@ def generate_k_cube_model_cylindrical_binning(
     """
     # define mod_k binning
     modkscaleterm = 1.5  # Value used in BEoRfgs and in 21cmFAST binning
-    deltakperp = 2.*np.pi / ps_box_size_para_Mpc
+    deltakperp = 2.0 * np.pi / ps_box_size_para_Mpc
     binsize = deltakperp * 2  # Value used in BEoRfgs
 
     numKbins = 50
@@ -292,7 +284,7 @@ def generate_k_cube_model_cylindrical_binning(
 
     for m1 in range(1, numKbins, 1):
         binsize = binsize * modkscaleterm
-        modkbins[m1, 0] = modkbins[m1-1, 1]
+        modkbins[m1, 0] = modkbins[m1 - 1, 1]
         modkbins[m1, 1] = modkscaleterm * modkbins[m1, 0]
 
     total_elements = 0
@@ -305,26 +297,30 @@ def generate_k_cube_model_cylindrical_binning(
         # added to the quadratic selector mask
         n_elements = np.sum(
             np.logical_and.reduce(
-                (mod_k_masked > modkbins[i_bin, 0],
-                 mod_k_masked <= modkbins[i_bin, 1],
-                 k_z_masked > 0)
+                (
+                    mod_k_masked > modkbins[i_bin, 0],
+                    mod_k_masked <= modkbins[i_bin, 1],
+                    k_z_masked > 0,
                 )
             )
+        )
         if n_elements > 0:
             n_bins += 1
             total_elements += n_elements
             modkbins_containing_voxels.append((modkbins[i_bin], n_elements))
 
     # define k_perp binning
-    k_perp_3D = (k_x_masked**2. + k_y_masked**2)**0.5
+    k_perp_3D = (k_x_masked**2.0 + k_y_masked**2) ** 0.5
     k_perp_min = k_perp_3D[np.isfinite(k_perp_3D)].min()
     k_perp_max = k_perp_3D[np.isfinite(k_perp_3D)].max()
 
     def output_k_perp_bins(k_perp_min, k_perp_max, n_k_perp_bins):
         k_perp_bins = np.vstack(
-            (np.linspace(k_perp_min*0.99, k_perp_max*1.01, n_k_perp_bins)[:-1],
-             np.linspace(k_perp_min*0.99, k_perp_max*1.01, n_k_perp_bins)[1:])
-            ).T
+            (
+                np.linspace(k_perp_min * 0.99, k_perp_max * 1.01, n_k_perp_bins)[:-1],
+                np.linspace(k_perp_min * 0.99, k_perp_max * 1.01, n_k_perp_bins)[1:],
+            )
+        ).T
         return k_perp_bins
 
     def return_k_perp_bins_with_voxels(k_perp_bins):
@@ -337,8 +333,8 @@ def generate_k_cube_model_cylindrical_binning(
             # included explicitly with the quadratic modes, then k_z==0
             # should be added to the quadratic selector mask
             k_perp_constraint = np.logical_and.reduce(
-                (k_perp_3D > k_perp_bins[i_bin][0],
-                 k_perp_3D <= k_perp_bins[i_bin][1]))
+                (k_perp_3D > k_perp_bins[i_bin][0], k_perp_3D <= k_perp_bins[i_bin][1])
+            )
             n_elements = np.sum(k_perp_constraint)
             if n_elements > 0:
                 n_bins += 1
@@ -350,16 +346,20 @@ def generate_k_cube_model_cylindrical_binning(
 
         return k_perp_bins_containing_voxels
 
-    n_k_perp_bins_array = [n_k_perp_bins
-                           for _ in range(len(modkbins_containing_voxels))]
+    n_k_perp_bins_array = [
+        n_k_perp_bins for _ in range(len(modkbins_containing_voxels))
+    ]
 
     # Currently using equal bin widths for all k_z but can make the
     # number of bins / the bin width a function of k_z if that turns out
     # to be useful (i.e. use larger bins at larger k_z where there is
     # less power).
-    k_perp_bins = [return_k_perp_bins_with_voxels(
-        output_k_perp_bins(k_perp_min, k_perp_max, n_k_perp_bins_val))
-        for n_k_perp_bins_val in n_k_perp_bins_array]
+    k_perp_bins = [
+        return_k_perp_bins_with_voxels(
+            output_k_perp_bins(k_perp_min, k_perp_max, n_k_perp_bins_val)
+        )
+        for n_k_perp_bins_val in n_k_perp_bins_array
+    ]
 
     k_cube_voxels_in_bin = []
     count = 0
@@ -371,17 +371,21 @@ def generate_k_cube_model_cylindrical_binning(
             # consistency with previous results when calculating the
             # cylindrical power spectrum with HERA 37.
             k_z_constraint = np.logical_and.reduce(
-                (abs(k_z_masked)
-                 > modkbins_containing_voxels[i_mod_k_bin][0][0],
-                 abs(k_z_masked)
-                 <= modkbins_containing_voxels[i_mod_k_bin][0][1],
-                 k_z_masked != 0)
+                (
+                    abs(k_z_masked) > modkbins_containing_voxels[i_mod_k_bin][0][0],
+                    abs(k_z_masked) <= modkbins_containing_voxels[i_mod_k_bin][0][1],
+                    k_z_masked != 0,
                 )
+            )
             k_perp_constraint = np.logical_and.reduce(
-                (k_perp_3D > k_perp_bins[i_mod_k_bin][j_k_perp_bin][0],
-                 k_perp_3D <= k_perp_bins[i_mod_k_bin][j_k_perp_bin][1]))
+                (
+                    k_perp_3D > k_perp_bins[i_mod_k_bin][j_k_perp_bin][0],
+                    k_perp_3D <= k_perp_bins[i_mod_k_bin][j_k_perp_bin][1],
+                )
+            )
             relevant_voxels = np.where(
-                np.logical_and(k_z_constraint, k_perp_constraint))
+                np.logical_and(k_z_constraint, k_perp_constraint)
+            )
             count += len(relevant_voxels[0])
             k_cube_voxels_in_bin.append(relevant_voxels)
 

--- a/bayeseor/model/noise.py
+++ b/bayeseor/model/noise.py
@@ -1,17 +1,18 @@
 import numpy as np
+from typing import Literal
 
 from ..utils import mpiprint
 
 
 def generate_gaussian_noise(
-    sigma,
-    s,
-    nf,
-    nt,
-    uvw_array_meters,
-    bl_redundancy_array,
-    random_seed='',
-    rank=0
+    sigma: float,
+    s: np.ndarray,
+    nf: int,
+    nt: int,
+    uvw_array_meters: np.ndarray,
+    bl_redundancy_array: np.ndarray,
+    random_seed: int | Literal[""] = "",
+    rank: int = 0
 ):
     """
     Generate and add Hermitian, Gaussian noise to noise-free visibilities.
@@ -51,17 +52,17 @@ def generate_gaussian_noise(
         pairs based on `uvw_array_meters`.
 
     """
+    nbls = len(uvw_array_meters)
     if sigma == 0.0:
         complex_noise_hermitian = np.zeros(len(s)) + 0.0j
     else:
-        nbls = len(uvw_array_meters)
         ndata = nbls * nt * nf
-        if random_seed:
+        if isinstance(random_seed, int) and random_seed != 0:
             mpiprint(f"Seeding numpy.random with {random_seed}", rank=rank)
             np.random.seed(random_seed)
         real_noise = np.random.normal(0, sigma/2.**0.5, ndata)
 
-        if random_seed:
+        if isinstance(random_seed, int) and random_seed != 0:
             np.random.seed(random_seed*123)
         imag_noise = np.random.normal(0, sigma/2.**0.5, ndata)
         complex_noise = real_noise + 1j*imag_noise

--- a/bayeseor/model/noise.py
+++ b/bayeseor/model/noise.py
@@ -12,7 +12,7 @@ def generate_gaussian_noise(
     uvw_array_meters: np.ndarray,
     bl_redundancy_array: np.ndarray,
     random_seed: int | Literal[""] = "",
-    rank: int = 0
+    rank: int = 0,
 ):
     """
     Generate and add Hermitian, Gaussian noise to noise-free visibilities.
@@ -60,13 +60,13 @@ def generate_gaussian_noise(
         if isinstance(random_seed, int) and random_seed != 0:
             mpiprint(f"Seeding numpy.random with {random_seed}", rank=rank)
             np.random.seed(random_seed)
-        real_noise = np.random.normal(0, sigma/2.**0.5, ndata)
+        real_noise = np.random.normal(0, sigma / 2.0**0.5, ndata)
 
         if isinstance(random_seed, int) and random_seed != 0:
-            np.random.seed(random_seed*123)
-        imag_noise = np.random.normal(0, sigma/2.**0.5, ndata)
-        complex_noise = real_noise + 1j*imag_noise
-        complex_noise = complex_noise * sigma/complex_noise.std()
+            np.random.seed(random_seed * 123)
+        imag_noise = np.random.normal(0, sigma / 2.0**0.5, ndata)
+        complex_noise = real_noise + 1j * imag_noise
+        complex_noise = complex_noise * sigma / complex_noise.std()
         complex_noise_hermitian = complex_noise.copy()
 
     """
@@ -83,8 +83,8 @@ def generate_gaussian_noise(
     # Only account for uv-redundancy for now so use
     # uvw_array_meters[:,:2] and exclude w-coordinate
     for i, uvw in enumerate(uvw_array_meters[:, :2]):
-        if tuple(uvw*-1) in bl_conjugate_pairs_dict.keys():
-            key = bl_conjugate_pairs_dict[tuple(uvw*-1)]
+        if tuple(uvw * -1) in bl_conjugate_pairs_dict.keys():
+            key = bl_conjugate_pairs_dict[tuple(uvw * -1)]
             bl_conjugate_pairs_dict[tuple(uvw)] = key
             bl_conjugate_pairs_map[key] = i
         else:
@@ -97,10 +97,12 @@ def generate_gaussian_noise(
             start_ind = time_ind + freq_ind
             for bl_ind in bl_conjugate_pairs_map.keys():
                 conj_bl_ind = bl_conjugate_pairs_map[bl_ind]
-                complex_noise_hermitian[start_ind+conj_bl_ind] =\
-                    complex_noise_hermitian[start_ind+bl_ind].conjugate()
-            complex_noise_hermitian[start_ind:start_ind+nbls] /=\
-                bl_redundancy_array[:, 0]**0.5
+                complex_noise_hermitian[start_ind + conj_bl_ind] = (
+                    complex_noise_hermitian[start_ind + bl_ind].conjugate()
+                )
+            complex_noise_hermitian[start_ind : start_ind + nbls] /= (
+                bl_redundancy_array[:, 0] ** 0.5
+            )
 
         d = s + complex_noise_hermitian.flatten()
 

--- a/bayeseor/params.py
+++ b/bayeseor/params.py
@@ -1,13 +1,6 @@
 """Analysis settings"""
-
-from copy import deepcopy
-
-import numpy as np
-from astropy import constants, units
 from jsonargparse import ActionConfigFile, ActionYesNo, ArgumentParser
-from jsonargparse.typing import List, Path_fr, path_type
-
-from .cosmology import Cosmology
+from jsonargparse.typing import Path_fr, path_type
 
 
 class BayesEoRParser(ArgumentParser):
@@ -449,7 +442,7 @@ class BayesEoRParser(ArgumentParser):
         # Prior Parameters
         self.add_argument(
             "--priors",
-            type=List[list],
+            type=list[list],
             help="Power spectrum prior range [min, max] for each k bin.",
         )
         self.add_argument(
@@ -569,7 +562,7 @@ class BayesEoRParser(ArgumentParser):
         )
         self.add_argument(
             "--beta",
-            type=List[float],
+            type=list[float],
             default=[2.63, 2.82],
             help="Brightness temperature power law spectral index/indices used in the "
             "large spectral scale model. Can be a single spectral index, '[2.63]', "
@@ -768,7 +761,7 @@ class BayesEoRParser(ArgumentParser):
         )
         self.add_argument(
             "--tele-latlonalt",
-            type=List[float],
+            type=list[float],
             dest="telescope_latlonalt",  # FIXME: remove need for dest
             help="Telescope location in latitude (deg), longitude (deg), and altitude "
             "(meters). Passed as a list of floats, e.g. '[30.1,125.6,80.4]'. Do not "
@@ -832,7 +825,7 @@ class BayesEoRParser(ArgumentParser):
         )
         self.add_argument(
             "--beam-center",
-            type=List[float],
+            type=list[float],
             help="Beam center offsets from the phase center in RA and Dec in degrees. "
             "Default behavior is the beam center aligns with the phase center. "
             "Passed as a list of floats, e.g. '[-1.3,0.01]'. Do not include a space "

--- a/bayeseor/posterior.py
+++ b/bayeseor/posterior.py
@@ -1,4 +1,6 @@
 import time
+from typing import Any, cast
+
 import numpy as np
 import scipy
 from pdb import set_trace as brk
@@ -316,6 +318,18 @@ class PowerSpectrumPosteriorProbability(object):
         dmps_norm *= self.inst_to_cosmo_vol**2
 
         return dmps_norm
+
+    def calc_Npix_physical_power_spectrum_normalisation(self, i_bin):
+        """
+        Physical power spectrum normalization in voxel units.
+
+        This path is not currently implemented. The code base currently
+        supports modelling the dimensionless power spectrum only.
+        """
+        raise NotImplementedError(
+            "Physical P(k) normalization is not currently implemented. "
+            "Use dimensionless_PS=True."
+        )
 
     def calc_PowerI(self, x):
         """
@@ -759,7 +773,7 @@ class PowerSpectrumPosteriorProbability(object):
                          rank=self.rank)
             start = time.time()
             with h5py.File(T_Ninv_T_file_path, 'r') as hf:
-                T_Ninv_T = hf[T_Ninv_T_dataset_name][:]
+                T_Ninv_T = cast(Any, hf[T_Ninv_T_dataset_name])[:]
                 # This is only valid if the data is uniformly weighted
                 # T_Ninv_T = T_Ninv_T/(alpha_prime**2.0)
                 if self.count % self.print_rate == 0:
@@ -777,7 +791,7 @@ class PowerSpectrumPosteriorProbability(object):
                          rank=self.rank)
             start = time.time()
             with h5py.File(dbar_file_path, 'r') as hf:
-                dbar = hf[dbar_dataset_name][:]
+                dbar = cast(Any, hf[dbar_dataset_name])[:]
                 # This is only valid if the data is uniformly weighted
                 # dbar = dbar/(alpha_prime**2.0)
                 # if self.count % self.print_rate == 0:

--- a/bayeseor/posterior.py
+++ b/bayeseor/posterior.py
@@ -28,6 +28,7 @@ class PriorC(object):
         [min2, max2], ...].
 
     """
+
     def __init__(self, priors_min_max):
         self.priors_min_max = priors_min_max
 
@@ -38,6 +39,7 @@ class PriorC(object):
             theta_i = pmm[i_p][0] + ((pmm[i_p][1] - pmm[i_p][0]) * cube[i_p])
             theta.append(theta_i)
         return theta
+
 
 class PowerSpectrumPosteriorProbability(object):
     r"""
@@ -125,7 +127,7 @@ class PowerSpectrumPosteriorProbability(object):
         MPI rank. Defaults to 0.
     use_gpu : bool, optional
         Use GPUs for the Cholesky decomposition of `Sigma`. Otherwise, use
-        CPUs (inadvisable due to potential inaccuracy of CPU matrix inversion).  
+        CPUs (inadvisable due to potential inaccuracy of CPU matrix inversion).
         Defaults to True.
     verbose : bool, optional
         Verbose output. Defaults to False.
@@ -138,6 +140,7 @@ class PowerSpectrumPosteriorProbability(object):
         output. Defaults to False.
 
     """
+
     def __init__(
         self,
         T_Ninv_T,
@@ -172,7 +175,7 @@ class PowerSpectrumPosteriorProbability(object):
         verbose=False,
         print_rate=100,
         debug=False,
-        print_debug=False
+        print_debug=False,
     ):
         self.instantiation_time = time.time()
 
@@ -203,12 +206,9 @@ class PowerSpectrumPosteriorProbability(object):
         else:
             self.block_T_Ninv_T = block_T_Ninv_T
         self.intrinsic_noise_fitting = intrinsic_noise_fitting
-        self.fit_for_spectral_model_parameters =\
-            fit_for_spectral_model_parameters
+        self.fit_for_spectral_model_parameters = fit_for_spectral_model_parameters
         if self.fit_for_spectral_model_parameters:
-            req_params = np.all(
-                [x is not None for x in [pl_max, pl_grid_spacing]]
-            )
+            req_params = np.all([x is not None for x in [pl_max, pl_grid_spacing]])
             if self.rank == 0:
                 assert req_params, (
                     "If fit_for_spectral_model_parameters is True, must pass "
@@ -225,11 +225,11 @@ class PowerSpectrumPosteriorProbability(object):
         self.print_debug = print_debug
         # Auxiliary params
         self.count = 0  # Iteration counter
-        self.neor_uveta = self.nuv*(self.neta - 1)  # EoR model parameters
+        self.neor_uveta = self.nuv * (self.neta - 1)  # EoR model parameters
         self.Npar = T_Ninv_T.shape[0]  # EoR+FG model parameters
         self.Sigma_diag_inds = np.diag_indices(self.Npar)
         self.alpha_prime = 1.0  # Initial noise fitting parameter value
-        # Conversion from observational k-cube voxel units [sr Hz] to comoving 
+        # Conversion from observational k-cube voxel units [sr Hz] to comoving
         # voxel units [Mpc^3]
         self.inst_to_cosmo_vol = Cosmology().inst_to_cosmo_vol(self.redshift)
         # Volume of model image cube in comoving coordinates
@@ -240,21 +240,17 @@ class PowerSpectrumPosteriorProbability(object):
         )
         # FIXME: add argument for location of pre-computed(?) arrays when
         # fitting for spectral model parameters?
-        self.spectral_model_parameters_array_storage_dir = ''
+        self.spectral_model_parameters_array_storage_dir = ""
 
         if self.verbose:
             if self.log_priors:
-                mpiprint('Using log-priors', rank=self.rank)
+                mpiprint("Using log-priors", rank=self.rank)
             if self.dimensionless_PS:
-                mpiprint(
-                    'Calculating the dimensionless power spectrum',
-                    rank=self.rank
-                )
+                mpiprint("Calculating the dimensionless power spectrum", rank=self.rank)
             mpiprint(
-                f"Setting inverse_LW_power to {self.inverse_LW_power}",
-                rank=self.rank
+                f"Setting inverse_LW_power to {self.inverse_LW_power}", rank=self.rank
             )
-        
+
         if use_gpu:
             # Initialize the GPU interface
             self.gpu = GPUInterface(rank=self.rank, verbose=self.verbose)
@@ -312,7 +308,7 @@ class PowerSpectrumPosteriorProbability(object):
         """
         # Normalization calculated relative to mean of vector k within the
         # i_bin-th k bin
-        dmps_norm = self.k_vals[i_bin]**3./(2*np.pi**2) / self.cosmo_volume
+        dmps_norm = self.k_vals[i_bin] ** 3.0 / (2 * np.pi**2) / self.cosmo_volume
 
         # Redshift dependent quantities
         dmps_norm *= self.inst_to_cosmo_vol**2
@@ -358,21 +354,22 @@ class PowerSpectrumPosteriorProbability(object):
         # vector ordering scheme.  This function needs to be updated and have
         # the deprecated variables removed.
         if self.include_instrumental_effects:
-            q0_index = self.neta//2
+            q0_index = self.neta // 2
         else:
-            q0_index = self.nf//2 - 1
+            q0_index = self.nf // 2 - 1
         q1_index = self.neta
         q2_index = self.neta + 1
         if self.use_shg:
             # FIXME: Needs to be updated for the new separate EoR and FG
             # models if used in the future!!!
-            cg_end = self.nuv*(self.neta - 1)
+            cg_end = self.nuv * (self.neta - 1)
         else:
             cg_end = None
 
         # Constrain LW mode amplitude distribution
-        dimensionless_PS_scaling =\
+        dimensionless_PS_scaling = (
             self.calc_physical_dimensionless_power_spectral_normalisation(0)
+        )
         # FIXME: Need to update the code in this if/else block to account
         # for the separate EoR and FG models if used in the future.  There is
         # currently no way to implement separate priors on the individual large
@@ -380,16 +377,19 @@ class PowerSpectrumPosteriorProbability(object):
         # to be identical accross all LSSM parameters.
         if self.use_LWM_Gaussian_prior:
             Fourier_mode_start_index = 3
-            PowerI[:cg_end][q0_index::self.neta+self.nq] =\
+            PowerI[:cg_end][q0_index :: self.neta + self.nq] = (
                 np.mean(dimensionless_PS_scaling) / x[0]
-            PowerI[:cg_end][q1_index::self.neta+self.nq] =\
+            )
+            PowerI[:cg_end][q1_index :: self.neta + self.nq] = (
                 np.mean(dimensionless_PS_scaling) / x[1]
-            PowerI[:cg_end][q2_index::self.neta+self.nq] =\
+            )
+            PowerI[:cg_end][q2_index :: self.neta + self.nq] = (
                 np.mean(dimensionless_PS_scaling) / x[2]
+            )
         else:
             Fourier_mode_start_index = 0
             # Set to zero (1e-16) for a uniform distribution
-            PowerI[self.neor_uveta:] = self.inverse_LW_power
+            PowerI[self.neor_uveta :] = self.inverse_LW_power
 
         if self.use_shg:
             # FIXME: Needs to be updated for the new separate EoR and FG
@@ -400,22 +400,23 @@ class PowerSpectrumPosteriorProbability(object):
             PowerI[cg_end:] = self.inverse_LW_power
 
         if self.dimensionless_PS:
-            self.power_spectrum_normalisation_func =\
+            self.power_spectrum_normalisation_func = (
                 self.calc_physical_dimensionless_power_spectral_normalisation
+            )
         else:
             # FIXME: see BayesEoR issue #59
             # Do we want to add support for modelling P(k)?
-            self.power_spectrum_normalisation_func =\
+            self.power_spectrum_normalisation_func = (
                 self.calc_Npix_physical_power_spectrum_normalisation
+            )
 
         # Fit for Fourier mode power spectrum
         for i_bin in range(len(self.k_cube_voxels_in_bin)):
-            power_spectrum_normalisation =\
-                self.power_spectrum_normalisation_func(i_bin)
+            power_spectrum_normalisation = self.power_spectrum_normalisation_func(i_bin)
             # NOTE: fitting for power not std here
             PowerI[self.k_cube_voxels_in_bin[i_bin]] = (
-                    power_spectrum_normalisation
-                    / x[Fourier_mode_start_index+i_bin])
+                power_spectrum_normalisation / x[Fourier_mode_start_index + i_bin]
+            )
 
         return PowerI
 
@@ -445,17 +446,19 @@ class PowerSpectrumPosteriorProbability(object):
         """
         PhiI_blocks = np.split(PhiI, self.nuv)
         Sigma_block_diagonals = np.array(
-            [self.add_power_to_diagonals(
-                T_Ninv_T[
-                    (self.neta + self.nq)*i_block:
-                        (self.neta + self.nq)*(i_block+1),
-                    (self.neta + self.nq)*i_block:
-                        (self.neta + self.nq)*(i_block+1)
+            [
+                self.add_power_to_diagonals(
+                    T_Ninv_T[
+                        (self.neta + self.nq) * i_block : (self.neta + self.nq)
+                        * (i_block + 1),
+                        (self.neta + self.nq) * i_block : (self.neta + self.nq)
+                        * (i_block + 1),
                     ],
-                PhiI_blocks[i_block]
+                    PhiI_blocks[i_block],
                 )
-                for i_block in range(self.nuv)]
-            )
+                for i_block in range(self.nuv)
+            ]
+        )
         return Sigma_block_diagonals
 
     def calc_SigmaI_dbar_wrapper(self, x, T_Ninv_T, dbar, block_T_Ninv_T=[]):
@@ -500,78 +503,83 @@ class PowerSpectrumPosteriorProbability(object):
         PowerI = self.calc_PowerI(x)
         PhiI = PowerI
         if self.verbose:
-            mpiprint('\tPhiI time: {}'.format(time.time()-start),
-                     rank=self.rank)
+            mpiprint("\tPhiI time: {}".format(time.time() - start), rank=self.rank)
 
         do_block_diagonal_inversion = len(np.shape(block_T_Ninv_T)) > 1
         if do_block_diagonal_inversion:
             if self.verbose:
-                mpiprint('Using block-diagonal inversion', rank=self.rank)
+                mpiprint("Using block-diagonal inversion", rank=self.rank)
             start = time.time()
             if self.intrinsic_noise_fitting:
                 # This is only valid if the data is uniformly weighted
                 Sigma_block_diagonals = self.calc_Sigma_block_diagonals(
-                    T_Ninv_T/self.alpha_prime**2., PhiI)
+                    T_Ninv_T / self.alpha_prime**2.0, PhiI
+                )
             else:
-                Sigma_block_diagonals = self.calc_Sigma_block_diagonals(
-                    T_Ninv_T, PhiI)
+                Sigma_block_diagonals = self.calc_Sigma_block_diagonals(T_Ninv_T, PhiI)
             if self.verbose:
-                mpiprint('Time taken: {}'.format(time.time()-start),
-                         rank=self.rank)
+                mpiprint("Time taken: {}".format(time.time() - start), rank=self.rank)
 
             start = time.time()
             dbar_blocks = np.split(dbar, self.nuv)
             if self.use_gpu:
                 if self.verbose:
-                    mpiprint('Computing block diagonal inversion on GPU',
-                             rank=self.rank)
+                    mpiprint(
+                        "Computing block diagonal inversion on GPU", rank=self.rank
+                    )
                 SigmaI_dbar_blocks_and_logdet_Sigma = np.array(
-                    [self.calc_SigmaI_dbar(
-                        Sigma_block_diagonals[i_block],
-                        dbar_blocks[i_block],
-                        x_for_error_checking=x
+                    [
+                        self.calc_SigmaI_dbar(
+                            Sigma_block_diagonals[i_block],
+                            dbar_blocks[i_block],
+                            x_for_error_checking=x,
                         )
-                     for i_block in range(self.nuv)]
-                    )
+                        for i_block in range(self.nuv)
+                    ]
+                )
                 SigmaI_dbar_blocks = np.array(
-                    [SigmaI_dbar_block
-                     for SigmaI_dbar_block, logdet_Sigma
-                     in SigmaI_dbar_blocks_and_logdet_Sigma]
-                    )
+                    [
+                        SigmaI_dbar_block
+                        for SigmaI_dbar_block, logdet_Sigma in SigmaI_dbar_blocks_and_logdet_Sigma
+                    ]
+                )
                 logdet_Sigma_blocks = SigmaI_dbar_blocks_and_logdet_Sigma[:, 1]
             else:
                 SigmaI_dbar_blocks = np.array(
-                    [self.calc_SigmaI_dbar(
-                        Sigma_block_diagonals[i_block],
-                        dbar_blocks[i_block],
-                        x_for_error_checking=x
+                    [
+                        self.calc_SigmaI_dbar(
+                            Sigma_block_diagonals[i_block],
+                            dbar_blocks[i_block],
+                            x_for_error_checking=x,
                         )
-                     for i_block in range(self.nuv)]
-                    )
+                        for i_block in range(self.nuv)
+                    ]
+                )
             if self.verbose:
-                mpiprint('Time taken: {}'.format(time.time()-start),
-                         rank=self.rank)
+                mpiprint("Time taken: {}".format(time.time() - start), rank=self.rank)
 
             SigmaI_dbar = SigmaI_dbar_blocks.flatten()
             dbarSigmaIdbar = np.dot(dbar.conjugate().T, SigmaI_dbar)
             if self.verbose:
-                mpiprint('Time taken: {}'.format(time.time()-start),
-                         rank=self.rank)
+                mpiprint("Time taken: {}".format(time.time() - start), rank=self.rank)
 
             if self.use_gpu:
                 logSigmaDet = np.sum(logdet_Sigma_blocks)
             else:
                 logSigmaDet = np.sum(
-                    [np.linalg.slogdet(Sigma_block)[1]
-                     for Sigma_block in Sigma_block_diagonals]
-                    )
+                    [
+                        np.linalg.slogdet(Sigma_block)[1]
+                        for Sigma_block in Sigma_block_diagonals
+                    ]
+                )
                 if self.verbose:
-                    mpiprint('Time taken: {}'.format(time.time()-start),
-                             rank=self.rank)
+                    mpiprint(
+                        "Time taken: {}".format(time.time() - start), rank=self.rank
+                    )
 
         else:
             if self.count % self.print_rate == 0 and self.verbose:
-                mpiprint('Not using block-diagonal inversion', rank=self.rank)
+                mpiprint("Not using block-diagonal inversion", rank=self.rank)
             start = time.time()
             # Note: the following two lines can probably be speeded up
             # by adding T_Ninv_T and np.diag(PhiI). (Should test this!)
@@ -579,39 +587,39 @@ class PowerSpectrumPosteriorProbability(object):
             # so will deal with it later.
             Sigma = T_Ninv_T.copy()
             if self.intrinsic_noise_fitting:
-                Sigma = Sigma/self.alpha_prime**2.0
+                Sigma = Sigma / self.alpha_prime**2.0
 
             Sigma[self.Sigma_diag_inds] += PhiI
             if self.verbose:
-                mpiprint('\tSigma build time: {}'.format(time.time()-start),
-                         rank=self.rank)
+                mpiprint(
+                    "\tSigma build time: {}".format(time.time() - start), rank=self.rank
+                )
             if self.return_Sigma:
                 return Sigma
 
             start = time.time()
             if self.use_gpu:
                 if self.verbose:
-                    mpiprint('Computing matrix inversion on GPU',
-                             rank=self.rank)
+                    mpiprint("Computing matrix inversion on GPU", rank=self.rank)
                 SigmaI_dbar_and_logdet_Sigma = self.calc_SigmaI_dbar(
-                    Sigma, dbar, x_for_error_checking=x)
+                    Sigma, dbar, x_for_error_checking=x
+                )
                 SigmaI_dbar = SigmaI_dbar_and_logdet_Sigma[0]
                 logdet_Sigma = SigmaI_dbar_and_logdet_Sigma[1]
             else:
-                SigmaI_dbar = self.calc_SigmaI_dbar(
-                    Sigma, dbar, x_for_error_checking=x)
+                SigmaI_dbar = self.calc_SigmaI_dbar(Sigma, dbar, x_for_error_checking=x)
             if self.verbose:
                 mpiprint(
-                    '\tcalc_SigmaI_dbar time: {}'.format(time.time()-start),
-                    rank=self.rank
+                    "\tcalc_SigmaI_dbar time: {}".format(time.time() - start),
+                    rank=self.rank,
                 )
 
             start = time.time()
             dbarSigmaIdbar = np.dot(dbar.conjugate().T, SigmaI_dbar)
             if self.verbose:
                 mpiprint(
-                    '\tdbarSigmaIdbar time: {}'.format(time.time()-start),
-                    rank=self.rank
+                    "\tdbarSigmaIdbar time: {}".format(time.time() - start),
+                    rank=self.rank,
                 )
 
             start = time.time()
@@ -621,8 +629,7 @@ class PowerSpectrumPosteriorProbability(object):
                 logSigmaDet = np.linalg.slogdet(Sigma)[1]
             if self.verbose:
                 mpiprint(
-                    '\tlogSigmaDet time: {}'.format(time.time()-start),
-                    rank=self.rank
+                    "\tlogSigmaDet time: {}".format(time.time() - start), rank=self.rank
                 )
 
         return SigmaI_dbar, dbarSigmaIdbar, PhiI, logSigmaDet
@@ -630,7 +637,7 @@ class PowerSpectrumPosteriorProbability(object):
     def calc_SigmaI_dbar(self, Sigma, dbar, x_for_error_checking=[]):
         """
         Solves the linear system `Sigma * a = dbar`.
-        
+
         Solved by calculating the Cholesky decomposition (if `self.use_gpu` is
         True) of the matrix ``Sigma = T_Ninv_T + PhiI``.  If not using GPUs to
         perform the matrix inversion, ``scipy.linalg.inv`` will be used.  This
@@ -677,17 +684,13 @@ class PowerSpectrumPosteriorProbability(object):
             # memory but testing shows 121 actually stores the lower-
             # triangular matrix in memory, which is what we use below.
             exit_status = self.gpu.magma_zpotrf(
-                121,
-                Sigma.shape[1],
-                Sigma,
-                Sigma.shape[0],
-                self.magma_info
+                121, Sigma.shape[1], Sigma, Sigma.shape[0], self.magma_info
             )
             self.gpu.magma_finalize()
             if self.verbose:
                 mpiprint(
-                    f'\t\tCholesky decomposition time: {time.time() - start}',
-                    rank=self.rank
+                    f"\t\tCholesky decomposition time: {time.time() - start}",
+                    rank=self.rank,
                 )
             # Note: After wrapmzpotrf, Sigma is actually
             # SigmaCho (i.e. L with Sigma = LL^T)
@@ -697,20 +700,21 @@ class PowerSpectrumPosteriorProbability(object):
             SigmaI_dbar = scipy.linalg.cho_solve((Sigma, True), dbar)
             if self.verbose:
                 mpiprint(
-                    '\t\tscipy cho_solve time: {}'.format(
-                        time.time() - start
-                    ),
-                    rank=self.rank
+                    "\t\tscipy cho_solve time: {}".format(time.time() - start),
+                    rank=self.rank,
                 )
             if exit_status != 0:
                 # If the inversion doesn't work, zero-weight the
                 # sample (may want to stop computing if this occurs?)
                 logdet_Magma_Sigma = np.inf
-                print(self.rank, ':',
-                      'GPU inversion error. '
-                      'Setting sample posterior probability to zero.')
-                print(self.rank, ':', 'Param values: ', x_for_error_checking)
-                print(self.rank, ':', f'info = {self.magma_info[0]}')
+                print(
+                    self.rank,
+                    ":",
+                    "GPU inversion error. "
+                    "Setting sample posterior probability to zero.",
+                )
+                print(self.rank, ":", "Param values: ", x_for_error_checking)
+                print(self.rank, ":", f"info = {self.magma_info[0]}")
 
             return SigmaI_dbar, logdet_Magma_Sigma
 
@@ -745,60 +749,67 @@ class PowerSpectrumPosteriorProbability(object):
             pl_params = x[:2]
             x = x[2:]
             if self.verbose:
-                mpiprint('pl_params', pl_params, rank=self.rank)
+                mpiprint("pl_params", pl_params, rank=self.rank)
             if self.verbose:
-                mpiprint('pl_grid_spacing, pl_max',
-                         self.pl_grid_spacing, self.pl_max,
-                         rank=self.rank)
+                mpiprint(
+                    "pl_grid_spacing, pl_max",
+                    self.pl_grid_spacing,
+                    self.pl_max,
+                    rank=self.rank,
+                )
             b1 = pl_params[0]
-            b2 = (b1
-                  + self.pl_grid_spacing
-                  + (self.pl_max - b1 - self.pl_grid_spacing)*pl_params[1]
-                  )
+            b2 = (
+                b1
+                + self.pl_grid_spacing
+                + (self.pl_max - b1 - self.pl_grid_spacing) * pl_params[1]
+            )
             # Round derived pl indices to nearest self.pl_grid_spacing
-            b1, b2 = (self.pl_grid_spacing
-                      * np.round(np.array([b1, b2]) / self.pl_grid_spacing, 0))
+            b1, b2 = self.pl_grid_spacing * np.round(
+                np.array([b1, b2]) / self.pl_grid_spacing, 0
+            )
             if self.verbose:
-                mpiprint('b1, b2', b1, b2, rank=self.rank)
+                mpiprint("b1, b2", b1, b2, rank=self.rank)
 
             # Load matrices associated with sampled beta params
-            T_Ninv_T_dataset_name =\
-                'T_Ninv_T_b1_{}_b2_{}'.format(b1, b2).replace('.', 'd')
+            T_Ninv_T_dataset_name = "T_Ninv_T_b1_{}_b2_{}".format(b1, b2).replace(
+                ".", "d"
+            )
             T_Ninv_T_file_path = (
-                    self.spectral_model_parameters_array_storage_dir
-                    + T_Ninv_T_dataset_name
-                    + '.h5')
+                self.spectral_model_parameters_array_storage_dir
+                + T_Ninv_T_dataset_name
+                + ".h5"
+            )
             if self.count % self.print_rate == 0:
-                mpiprint('Replacing T_Ninv_T with:', T_Ninv_T_file_path,
-                         rank=self.rank)
+                mpiprint("Replacing T_Ninv_T with:", T_Ninv_T_file_path, rank=self.rank)
             start = time.time()
-            with h5py.File(T_Ninv_T_file_path, 'r') as hf:
+            with h5py.File(T_Ninv_T_file_path, "r") as hf:
                 T_Ninv_T = cast(Any, hf[T_Ninv_T_dataset_name])[:]
                 # This is only valid if the data is uniformly weighted
                 # T_Ninv_T = T_Ninv_T/(alpha_prime**2.0)
                 if self.count % self.print_rate == 0:
-                    mpiprint('Time taken: {}'.format(time.time() - start),
-                             rank=self.rank)
+                    mpiprint(
+                        "Time taken: {}".format(time.time() - start), rank=self.rank
+                    )
 
-            dbar_dataset_name =\
-                'dbar_b1_{}_b2_{}'.format(b1, b2).replace('.', 'd')
+            dbar_dataset_name = "dbar_b1_{}_b2_{}".format(b1, b2).replace(".", "d")
             dbar_file_path = (
-                    self.spectral_model_parameters_array_storage_dir
-                    + dbar_dataset_name
-                    + '.h5')
+                self.spectral_model_parameters_array_storage_dir
+                + dbar_dataset_name
+                + ".h5"
+            )
             if self.count % self.print_rate == 0:
-                mpiprint('Replacing dbar with:', dbar_file_path,
-                         rank=self.rank)
+                mpiprint("Replacing dbar with:", dbar_file_path, rank=self.rank)
             start = time.time()
-            with h5py.File(dbar_file_path, 'r') as hf:
+            with h5py.File(dbar_file_path, "r") as hf:
                 dbar = cast(Any, hf[dbar_dataset_name])[:]
                 # This is only valid if the data is uniformly weighted
                 # dbar = dbar/(alpha_prime**2.0)
                 # if self.count % self.print_rate == 0:
                 #     mpiprint('alpha_prime = ', alpha_prime, rank=self.rank)
                 if self.count % self.print_rate == 0:
-                    mpiprint('Time taken: {}'.format(time.time() - start),
-                             rank=self.rank)
+                    mpiprint(
+                        "Time taken: {}".format(time.time() - start), rank=self.rank
+                    )
 
         if self.intrinsic_noise_fitting:
             self.alpha_prime = x[0]
@@ -811,7 +822,7 @@ class PowerSpectrumPosteriorProbability(object):
             dbar = dbar / (self.alpha_prime**2.0)
 
         if self.log_priors:
-            x = 10.**np.array(x)
+            x = 10.0 ** np.array(x)
 
         do_block_diagonal_inversion = len(np.shape(block_T_Ninv_T)) > 1
         self.count += 1
@@ -819,23 +830,23 @@ class PowerSpectrumPosteriorProbability(object):
         try:
             if do_block_diagonal_inversion:
                 if self.verbose:
-                    mpiprint('Using block-diagonal inversion', rank=self.rank)
-                SigmaI_dbar, dbarSigmaIdbar, PhiI, logSigmaDet =\
+                    mpiprint("Using block-diagonal inversion", rank=self.rank)
+                SigmaI_dbar, dbarSigmaIdbar, PhiI, logSigmaDet = (
                     self.calc_SigmaI_dbar_wrapper(
-                        x, T_Ninv_T, dbar, block_T_Ninv_T=block_T_Ninv_T)
+                        x, T_Ninv_T, dbar, block_T_Ninv_T=block_T_Ninv_T
+                    )
+                )
             else:
                 if self.verbose:
-                    mpiprint('Not using block-diagonal inversion',
-                             rank=self.rank)
+                    mpiprint("Not using block-diagonal inversion", rank=self.rank)
                 start = time.time()
-                SigmaI_dbar, dbarSigmaIdbar, PhiI, logSigmaDet =\
+                SigmaI_dbar, dbarSigmaIdbar, PhiI, logSigmaDet = (
                     self.calc_SigmaI_dbar_wrapper(x, T_Ninv_T, dbar)
+                )
                 if self.verbose:
                     mpiprint(
-                        'calc_SigmaI_dbar_wrapper time: {}'.format(
-                            time.time() - start
-                        ),
-                        rank=self.rank
+                        "calc_SigmaI_dbar_wrapper time: {}".format(time.time() - start),
+                        rank=self.rank,
                     )
 
             # Only possible because Phi is diagonal (otherwise would
@@ -846,61 +857,70 @@ class PowerSpectrumPosteriorProbability(object):
             start = time.time()
             logPhiDet = -1 * np.sum(np.log(PhiI)).real
             if self.verbose:
-                mpiprint('logPhiDet time: {}'.format(time.time() - start),
-                         rank=self.rank)
+                mpiprint(
+                    "logPhiDet time: {}".format(time.time() - start), rank=self.rank
+                )
 
             start = time.time()
-            MargLogL = -0.5*logSigmaDet - 0.5*logPhiDet + 0.5*dbarSigmaIdbar
+            MargLogL = -0.5 * logSigmaDet - 0.5 * logPhiDet + 0.5 * dbarSigmaIdbar
             if self.uprior_inds is not None:
                 MargLogL += np.sum(np.log(x[self.uprior_inds]))
             if self.intrinsic_noise_fitting:
-                MargLogL = MargLogL - 0.5*d_Ninv_d - 0.5*log_det_N
+                MargLogL = MargLogL - 0.5 * d_Ninv_d - 0.5 * log_det_N
             MargLogL = MargLogL.real
             if self.verbose:
-                mpiprint('MargLogL time: {}'.format(time.time() - start),
-                         rank=self.rank)
+                mpiprint(
+                    "MargLogL time: {}".format(time.time() - start), rank=self.rank
+                )
             if self.print_debug:
-                MargLogL_equation_string = \
-                    'MargLogL = -0.5*logSigmaDet '\
-                    '-0.5*logPhiDet + 0.5*dbarSigmaIdbar'
+                MargLogL_equation_string = (
+                    "MargLogL = -0.5*logSigmaDet -0.5*logPhiDet + 0.5*dbarSigmaIdbar"
+                )
                 if self.intrinsic_noise_fitting:
-                    print(self.rank, ':', 'Using intrinsic noise fitting')
-                    MargLogL_equation_string +=\
-                        ' - 0.5*d_Ninv_d -0.5*log_det_N'
+                    print(self.rank, ":", "Using intrinsic noise fitting")
+                    MargLogL_equation_string += " - 0.5*d_Ninv_d -0.5*log_det_N"
                     print(
-                        self.rank, ':',
-                        'logSigmaDet, logPhiDet, dbarSigmaIdbar, '
-                        'd_Ninv_d, log_det_N',
-                        logSigmaDet, logPhiDet, dbarSigmaIdbar,
-                        d_Ninv_d, log_det_N
+                        self.rank,
+                        ":",
+                        "logSigmaDet, logPhiDet, dbarSigmaIdbar, d_Ninv_d, log_det_N",
+                        logSigmaDet,
+                        logPhiDet,
+                        dbarSigmaIdbar,
+                        d_Ninv_d,
+                        log_det_N,
                     )
                 else:
                     print(
-                        self.rank, ':',
-                        'logSigmaDet, logPhiDet, dbarSigmaIdbar',
-                        logSigmaDet, logPhiDet, dbarSigmaIdbar
+                        self.rank,
+                        ":",
+                        "logSigmaDet, logPhiDet, dbarSigmaIdbar",
+                        logSigmaDet,
+                        logPhiDet,
+                        dbarSigmaIdbar,
                     )
-                print(self.rank, ':', MargLogL_equation_string, MargLogL)
-                print(self.rank, ':', 'MargLogL.real', MargLogL.real)
+                print(self.rank, ":", MargLogL_equation_string, MargLogL)
+                print(self.rank, ":", "MargLogL.real", MargLogL.real)
 
             if self.count % self.print_rate == 0:
-                mpiprint('count', self.count, rank=self.rank)
+                mpiprint("count", self.count, rank=self.rank)
                 print(
-                    self.rank, ':',
-                    'Time since class instantiation: {}'.format(
+                    self.rank,
+                    ":",
+                    "Time since class instantiation: {}".format(
                         time.time() - self.instantiation_time
-                    )
+                    ),
                 )
                 print(
-                    self.rank, ':',
-                    'Time for this likelihood call: {}'.format(
+                    self.rank,
+                    ":",
+                    "Time for this likelihood call: {}".format(
                         time.time() - start_call
-                    )
+                    ),
                 )
-            return MargLogL.squeeze()*1.0, phi
+            return MargLogL.squeeze() * 1.0, phi
         except Exception as e:
             # This won't catch a warning if, for example, PhiI contains
             # any zeros in np.sum(np.log(PhiI))
-            print(self.rank, ':', 'Exception encountered...')
-            print(self.rank, ':', repr(e))
+            print(self.rank, ":", "Exception encountered...")
+            print(self.rank, ":", repr(e))
             return -np.inf, -1

--- a/bayeseor/setup.py
+++ b/bayeseor/setup.py
@@ -3,7 +3,15 @@
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Literal, NotRequired, TypedDict, TypeAlias, cast, overload
+from typing import (
+    Any,
+    Literal,
+    NotRequired,
+    TypeAlias,
+    TypedDict,
+    cast,
+    overload,
+)
 
 import numpy as np
 from astropy import units
@@ -33,7 +41,6 @@ from .utils import (
 )
 from .vis import preprocess_uvdata
 
-
 FloatArray: TypeAlias = NDArray[np.float64]
 ComplexArray: TypeAlias = NDArray[np.complex128]
 KCubeVoxels: TypeAlias = list[Any]
@@ -42,7 +49,7 @@ KCubeVoxels: TypeAlias = list[Any]
 class VisibilityData(TypedDict):
     vis_noisy: ComplexArray
     noise: ComplexArray
-    bl_conj_pairs_map: NDArray[np.int_]
+    bl_conj_pairs_map: Any
     uvws: FloatArray
     redundancy: FloatArray
     freqs: FloatArray
@@ -1593,7 +1600,8 @@ def get_vis_data(
                     else float(df)
                 )
                 freqs = np.asarray(
-                    freq_start_hz + np.arange(nf, dtype=float) * channel_width_hz,
+                    freq_start_hz
+                    + np.arange(nf, dtype=float) * channel_width_hz,
                     dtype=float,
                 )
             else:
@@ -1618,7 +1626,11 @@ def get_vis_data(
                 dt_days = (
                     float(cast(Any, dt).to_value(units.d))
                     if isinstance(dt, Quantity)
-                    else float(cast(Any, Quantity(float(dt), units.s).to_value(units.d)))
+                    else float(
+                        cast(
+                            Any, Quantity(float(dt), units.s).to_value(units.d)
+                        )
+                    )
                 )
                 jd_start = float(cast(Any, Time(jd_min, format="jd")).jd)
                 jds = np.asarray(
@@ -1630,12 +1642,19 @@ def get_vis_data(
                 dt_days = (
                     float(cast(Any, dt).to_value(units.d))
                     if isinstance(dt, Quantity)
-                    else float(cast(Any, Quantity(float(dt), units.s).to_value(units.d)))
+                    else float(
+                        cast(
+                            Any, Quantity(float(dt), units.s).to_value(units.d)
+                        )
+                    )
                 )
-                jd_center_val = float(cast(Any, Time(jd_center, format="jd")).jd)
+                jd_center_val = float(
+                    cast(Any, Time(jd_center, format="jd")).jd
+                )
                 jds = np.asarray(
                     jd_center_val
-                    + np.arange(-(nt // 2), nt // 2 + nt % 2, dtype=float) * dt_days,
+                    + np.arange(-(nt // 2), nt // 2 + nt % 2, dtype=float)
+                    * dt_days,
                     dtype=float,
                 )
             df = float(channel_width_hz)
@@ -1739,7 +1758,7 @@ def get_vis_data(
         vis_dict: VisibilityData = {
             "vis_noisy": cast(ComplexArray, vis_noisy),
             "noise": cast(ComplexArray, noise),
-            "bl_conj_pairs_map": np.asarray(bl_conj_pairs_map, dtype=int),
+            "bl_conj_pairs_map": bl_conj_pairs_map,
             "uvws": cast(FloatArray, uvws),
             "redundancy": cast(FloatArray, redundancy),
             "freqs": np.asarray(freqs, dtype=float),

--- a/bayeseor/setup.py
+++ b/bayeseor/setup.py
@@ -3,11 +3,13 @@
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any, Literal, NotRequired, TypedDict, TypeAlias, cast, overload
 
 import numpy as np
 from astropy import units
 from astropy.time import Time
 from astropy.units import Quantity
+from numpy.typing import NDArray
 from pyuvdata import __version__ as pyuvdata_version
 from rich.panel import Panel
 from scipy import sparse
@@ -30,6 +32,174 @@ from .utils import (
     save_numpy_dict,
 )
 from .vis import preprocess_uvdata
+
+
+FloatArray: TypeAlias = NDArray[np.float64]
+ComplexArray: TypeAlias = NDArray[np.complex128]
+KCubeVoxels: TypeAlias = list[Any]
+
+
+class VisibilityData(TypedDict):
+    vis_noisy: ComplexArray
+    noise: ComplexArray
+    bl_conj_pairs_map: NDArray[np.int_]
+    uvws: FloatArray
+    redundancy: FloatArray
+    freqs: FloatArray
+    df: float
+    jds: FloatArray
+    dt: float
+    vis: NotRequired[ComplexArray]
+    antpairs: NotRequired[Any]
+    phasor: NotRequired[ComplexArray | None]
+    tele_name: NotRequired[str]
+    uvd: NotRequired[Any]
+
+
+RunSetupBaseReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+]
+RunSetupWithVisReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    VisibilityData,
+]
+RunSetupWithKsReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    FloatArray,
+    KCubeVoxels,
+]
+RunSetupWithBmReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    BuildMatrices,
+]
+RunSetupWithVisBmReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    VisibilityData,
+    BuildMatrices,
+]
+RunSetupWithVisKsReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    VisibilityData,
+    FloatArray,
+    KCubeVoxels,
+]
+RunSetupWithKsBmReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    FloatArray,
+    KCubeVoxels,
+    BuildMatrices,
+]
+RunSetupWithVisKsBmReturn: TypeAlias = tuple[
+    PowerSpectrumPosteriorProbability,
+    Path,
+    VisibilityData,
+    FloatArray,
+    KCubeVoxels,
+    BuildMatrices,
+]
+
+
+@overload
+def run_setup(
+    *,
+    return_bm_immediately: Literal[True],
+    **kwargs: Any,
+) -> BuildMatrices: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[False] = False,
+    return_ks: Literal[False] = False,
+    return_bm: Literal[False] = False,
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupBaseReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[True],
+    return_ks: Literal[False] = False,
+    return_bm: Literal[False] = False,
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithVisReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[False] = False,
+    return_ks: Literal[True],
+    return_bm: Literal[False] = False,
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithKsReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[False] = False,
+    return_ks: Literal[False] = False,
+    return_bm: Literal[True],
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithBmReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[True],
+    return_ks: Literal[True],
+    return_bm: Literal[False] = False,
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithVisKsReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[True],
+    return_ks: Literal[False] = False,
+    return_bm: Literal[True],
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithVisBmReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[False] = False,
+    return_ks: Literal[True],
+    return_bm: Literal[True],
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithKsBmReturn: ...
+
+
+@overload
+def run_setup(
+    *,
+    return_vis: Literal[True],
+    return_ks: Literal[True],
+    return_bm: Literal[True],
+    return_bm_immediately: Literal[False] = False,
+    **kwargs: Any,
+) -> RunSetupWithVisKsBmReturn: ...
 
 
 def run_setup(
@@ -57,7 +227,7 @@ def run_setup(
     drift_scan: bool = True,
     include_instrumental_effects: bool = True,
     beam_type: str,
-    beam_center: list[float, float] | None = None,
+    beam_center: Sequence[float] | None = None,
     achromatic_beam: bool = False,
     beam_peak_amplitude: float = 1.0,
     fwhm_deg: float | None = None,
@@ -100,7 +270,7 @@ def run_setup(
     output_dir: Path | str = "./",
     mkdir: bool = True,
     file_root_dir: str | None = None,
-    priors: Sequence[float],
+    priors: Sequence[Sequence[float]],
     log_priors: bool = False,
     uprior_bins: str = "",
     uprior_inds: np.ndarray | None = None,
@@ -117,8 +287,18 @@ def run_setup(
     return_bm: bool = False,
     return_bm_immediately: bool = False,
     verbose: bool = False,
-    rank: bool = 0,
+    rank: int = 0,
     **kwargs,
+) -> (
+    BuildMatrices
+    | RunSetupBaseReturn
+    | RunSetupWithVisReturn
+    | RunSetupWithKsReturn
+    | RunSetupWithBmReturn
+    | RunSetupWithVisKsReturn
+    | RunSetupWithVisBmReturn
+    | RunSetupWithKsBmReturn
+    | RunSetupWithVisKsBmReturn
 ):
     """
     Run setup steps.
@@ -489,6 +669,8 @@ def run_setup(
         Matrix building class instance. Returned only if `return_bm` is True.
 
     """
+    prior_list = [list(prior) for prior in priors]
+
     if use_intrinsic_noise_fitting:
         # FIXME
         raise NotImplementedError(
@@ -515,6 +697,10 @@ def run_setup(
         raise ValueError(
             "telescope_latlonalt cannot be None if include_instrumental_effects is true"
         )
+    if not isinstance(data_path, Path):
+        data_path = Path(data_path)
+    if sigma is None:
+        raise ValueError("sigma cannot be None")
 
     # print_rank will only trigger print if verbose is True and rank == 0
     print_rank = 1 - (verbose and rank == 0)
@@ -586,16 +772,17 @@ def run_setup(
     noise = vis_dict["noise"]
     uvws = vis_dict["uvws"]
     redundancy = vis_dict["redundancy"]
-    nf = len(vis_dict["freqs"])
-    nu_min_MHz = (vis_dict["freqs"][0] * units.Hz).to("MHz").value
-    channel_width_MHz = (vis_dict["df"] * units.Hz).to("MHz").value
-    nt = len(vis_dict["jds"])
-    jd_center = vis_dict["jds"][nt // 2]
-    dt = vis_dict["dt"]
-    if "phasor" in vis_dict:
-        phasor = vis_dict["phasor"]
-    else:
-        phasor = None
+    freqs_hz = np.asarray(vis_dict["freqs"], dtype=float)
+    df_hz = float(vis_dict["df"])
+    jds_array = np.asarray(vis_dict["jds"], dtype=float)
+    dt_seconds = float(vis_dict["dt"])
+    nf = len(freqs_hz)
+    nu_min_MHz = float(freqs_hz[0] / 1e6)
+    channel_width_MHz = float(df_hz / 1e6)
+    nt = len(jds_array)
+    jd_center = float(jds_array[nt // 2])
+    dt = dt_seconds
+    phasor = vis_dict.get("phasor")
 
     # Assign optional kwargs if None
     # Model k cube params
@@ -624,7 +811,7 @@ def run_setup(
     if nq > npl:
         nq = npl
     # Subharmonic grid params
-    use_shg = np.any([kwarg is not None for kwarg in [nu_sh, nv_sh]])
+    use_shg = bool(np.any([kwarg is not None for kwarg in [nu_sh, nv_sh]]))
     if use_shg:
         if nu_sh is None:
             raise ValueError("nu_sh is required if using the subharmonic grid")
@@ -633,18 +820,18 @@ def run_setup(
 
     # Derived params
     cosmo = Cosmology()
-    redshift = cosmo.f2z(vis_dict["freqs"].mean() * units.Hz)
-    bandwidth = (vis_dict["df"] * units.Hz) * nf
+    redshift = cosmo.f2z(freqs_hz.mean() * units.Hz)
+    bandwidth_hz = df_hz * nf
     # EoR model
     # Spacing along the eta axis (line-of-sight Fourier dual to frequency)
     # defined as one over the bandwidth in Hz [1/Hz].
-    deta = 1 / bandwidth.to("Hz").value
+    deta = 1.0 / bandwidth_hz
     # Spacing along the u-axis of the EoR model uv-plane [1/rad]
     du_eor = 1 / np.deg2rad(fov_ra_eor)
     # Spacing along the v-axis of the EoR model uv-plane [1/rad]
     dv_eor = 1 / np.deg2rad(fov_dec_eor)
     # Comoving line-of-sight size of the EoR volume [Mpc]
-    ps_box_size_para_Mpc = cosmo.dL_df(redshift) * bandwidth.to("Hz").value
+    ps_box_size_para_Mpc = cosmo.dL_df(redshift) * bandwidth_hz
     # Comoving transverse size of the EoR volume along RA [Mpc]
     ps_box_size_ra_Mpc = cosmo.dL_dth(redshift) * np.deg2rad(fov_ra_eor)
     # Comoving transverse size of the EoR volume along Dec [Mpc]
@@ -660,7 +847,7 @@ def run_setup(
             beam_ref_freq = nu_min_MHz
         else:
             # Hz -> MHz for compatibility with BuildMatrices
-            beam_ref_freq = (beam_ref_freq * units.Hz).to("MHz").value
+            beam_ref_freq = Quantity(beam_ref_freq, units.Hz).to("MHz").value
 
     # Output directory generation
     if not isinstance(output_dir, Path):
@@ -713,8 +900,10 @@ def run_setup(
             save_dir = sampler_dir
         elif not isinstance(save_dir, Path):
             save_dir = Path(save_dir)
+        assert isinstance(save_dir, Path)
         save_dir.mkdir(exist_ok=True, parents=True)
     if save_vis:
+        assert isinstance(save_dir, Path)
         vis_path = save_dir / "vis_noisy.npy"
         mpiprint("\nSaving data vector(s) to disk.", rank=print_rank)
         mpiprint(f"\tVisibility vector: {vis_path}", rank=print_rank)
@@ -731,6 +920,8 @@ def run_setup(
             noise_path, noise, vis_args, extra=extra, clobber=clobber
         )
     if save_model:
+        assert isinstance(save_dir, Path)
+        assert "antpairs" in vis_dict
         mpiprint("\nSaving instrument model to disk.", rank=print_rank)
         # If data_path points to a numpy-compatible file, then an instrument
         # model is required as input and there's no reason to save the
@@ -790,6 +981,9 @@ def run_setup(
     vox_per_bin = [len(kinds[0]) for kinds in k_cube_voxels_in_bin]
     mpiprint(f"Voxels per bin: {vox_per_bin}", rank=print_rank)
 
+    jd_center_float = float(vis_dict["jds"][nt // 2])
+    dt_seconds = float(vis_dict["dt"])
+
     mpiprint("\n", Panel("Matrices"), rank=print_rank)
     bm = build_matrices(
         nu=nu,
@@ -828,12 +1022,12 @@ def run_setup(
         redundancy=redundancy,
         phasor=phasor,
         nt=nt,
-        jd_center=jd_center,
-        dt=dt,
+        jd_center=jd_center_float,
+        dt=dt_seconds,
         beam_type=beam_type,
         beam_center=beam_center,
         achromatic_beam=achromatic_beam,
-        beam_peak_amplitude=beam_peak_amplitude,
+        beam_peak_amplitude=float(beam_peak_amplitude),
         fwhm_deg=fwhm_deg,
         antenna_diameter=antenna_diameter,
         cosfreq=cosfreq,
@@ -859,16 +1053,16 @@ def run_setup(
     # Temporarily suppress output from bm.dot_product
     bm_verbose = bm.verbose
     bm.verbose = False
-    Ninv = bm.read_data("Ninv")
-    T = bm.read_data("T")
+    Ninv = cast(np.ndarray[Any, Any] | sparse.spmatrix, bm.read_data("Ninv"))
+    T = cast(np.ndarray[Any, Any], bm.read_data("T"))
     Ninv_d = bm.dot_product(Ninv, vis_noisy)
     dbar = bm.dot_product(T.conj().T, Ninv_d)
     d_Ninv_d = np.dot(vis_noisy.conj(), Ninv_d)
-    T_Ninv_T = bm.read_data("T_Ninv_T")
+    T_Ninv_T = cast(np.ndarray[Any, Any], bm.read_data("T_Ninv_T"))
     if include_instrumental_effects:
         block_T_Ninv_T = []
     else:
-        block_T_Ninv_T = bm.read_data("block_T_Ninv_T")
+        block_T_Ninv_T = cast(list[Any], bm.read_data("block_T_Ninv_T"))
     n_dims = k_vals.size
     bm.verbose = bm_verbose
 
@@ -888,16 +1082,16 @@ def run_setup(
         fg_log_priors_max = 6.0
         # priors[0] = [fg_log_priors_min, 8.0] # Set
         # Calibrate LW model priors using white noise fitting
-        priors[0] = [fg_log_priors_min, fg_log_priors_max]
-        priors[1] = [fg_log_priors_min, fg_log_priors_max]
-        priors[2] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[0] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[1] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[2] = [fg_log_priors_min, fg_log_priors_max]
         if use_intrinsic_noise_fitting:
-            priors[1] = priors[0]
-            priors[2] = priors[1]
-            priors[3] = priors[2]
-            priors[0] = [1.0, 2.0]  # Linear alpha_prime range
+            prior_list[1] = prior_list[0]
+            prior_list[2] = prior_list[1]
+            prior_list[3] = prior_list[2]
+            prior_list[0] = [1.0, 2.0]  # Linear alpha_prime range
     elif use_intrinsic_noise_fitting:
-        priors[0] = [1.0, 2.0]  # Linear alpha_prime range
+        prior_list[0] = [1.0, 2.0]  # Linear alpha_prime range
 
     cosmo = Cosmology()
     redshift = cosmo.f2z(bm.freqs_hertz.mean())
@@ -939,7 +1133,7 @@ def run_setup(
         block_T_Ninv_T=block_T_Ninv_T,
         use_shg=use_shg,
         use_gpu=use_gpu,
-        priors=priors,
+        priors=prior_list,
         uprior_inds=uprior_inds,
         use_intrinsic_noise_fitting=use_intrinsic_noise_fitting,
         use_LWM_Gaussian_prior=use_LWM_Gaussian_prior,
@@ -947,14 +1141,21 @@ def run_setup(
         rank=rank,
     )
 
-    return_vals = (pspp, sampler_dir)
+    if return_vis and return_ks and return_bm:
+        return (pspp, sampler_dir, vis_dict, k_vals, k_cube_voxels_in_bin, bm)
+    if return_vis and return_ks:
+        return (pspp, sampler_dir, vis_dict, k_vals, k_cube_voxels_in_bin)
+    if return_vis and return_bm:
+        return (pspp, sampler_dir, vis_dict, bm)
+    if return_ks and return_bm:
+        return (pspp, sampler_dir, k_vals, k_cube_voxels_in_bin, bm)
     if return_vis:
-        return_vals += (vis_dict,)
+        return (pspp, sampler_dir, vis_dict)
     if return_ks:
-        return_vals += (k_vals, k_cube_voxels_in_bin)
+        return (pspp, sampler_dir, k_vals, k_cube_voxels_in_bin)
     if return_bm:
-        return_vals += (bm,)
-    return return_vals
+        return (pspp, sampler_dir, bm)
+    return (pspp, sampler_dir)
 
 
 def generate_file_root_directory(
@@ -1116,7 +1317,7 @@ def get_vis_data(
     verbose: bool = False,
     rank: int = 0,
     **kwargs,
-):
+) -> VisibilityData:
     """
     Load or generate a one-dimensional visibility vector.
 
@@ -1341,6 +1542,10 @@ def get_vis_data(
                     "inst_model is required when loading a preprocessed data "
                     "vector (data_path has a .npy suffix)"
                 )
+            assert nf is not None
+            assert df is not None
+            assert nt is not None
+            assert dt is not None
 
             if not isinstance(inst_model, Path):
                 inst_model = Path(inst_model)
@@ -1358,37 +1563,87 @@ def get_vis_data(
                 "\nLoading numpy-compatible data:", style="bold", rank=rank
             )
             mpiprint(f"\nReading data from: {data_path}", rank=rank)
-            vis = load_numpy_dict(data_path)
+            vis = cast(ComplexArray, load_numpy_dict(data_path))
 
             mpiprint(f"Reading instrument model from: {inst_model}", rank=rank)
             uvws, redundancy, antpairs, phasor = load_inst_model(inst_model)
+            uvws = cast(FloatArray, uvws)
+            redundancy = cast(FloatArray, redundancy)
 
             if noise_data_path is not None:
                 if not isinstance(noise_data_path, Path):
                     noise_data_path = Path(noise_data_path)
                 if not noise_data_path.exists():
                     raise FileNotFoundError(f"{noise_data_path} does not exist")
-                noise = load_numpy_dict(noise_data_path)
+                noise = cast(ComplexArray, load_numpy_dict(noise_data_path))
             else:
                 noise = None
 
             tele_name = None
             uvd = None
             if freq_min is not None:
-                freqs = freq_min + np.arange(nf) * df
+                freq_start_hz = (
+                    float(cast(Any, freq_min).to_value(units.Hz))
+                    if isinstance(freq_min, Quantity)
+                    else float(freq_min)
+                )
+                channel_width_hz = (
+                    float(cast(Any, df).to_value(units.Hz))
+                    if isinstance(df, Quantity)
+                    else float(df)
+                )
+                freqs = np.asarray(
+                    freq_start_hz + np.arange(nf, dtype=float) * channel_width_hz,
+                    dtype=float,
+                )
             else:
-                freqs = (
-                    freq_center + np.arange(-(nf // 2), nf // 2 + nf % 2) * df
+                assert freq_center is not None
+                center_freq_hz = (
+                    float(cast(Any, freq_center).to_value(units.Hz))
+                    if isinstance(freq_center, Quantity)
+                    else float(freq_center)
+                )
+                channel_width_hz = (
+                    float(cast(Any, df).to_value(units.Hz))
+                    if isinstance(df, Quantity)
+                    else float(df)
+                )
+                freqs = np.asarray(
+                    center_freq_hz
+                    + np.arange(-(nf // 2), nf // 2 + nf % 2, dtype=float)
+                    * channel_width_hz,
+                    dtype=float,
                 )
             if jd_min is not None:
-                jds = Time(jd_min, format="jd") + np.arange(nt) * (
-                    dt * units.s
-                ).to("d")
+                dt_days = (
+                    float(cast(Any, dt).to_value(units.d))
+                    if isinstance(dt, Quantity)
+                    else float(cast(Any, Quantity(float(dt), units.s).to_value(units.d)))
+                )
+                jd_start = float(cast(Any, Time(jd_min, format="jd")).jd)
+                jds = np.asarray(
+                    jd_start + np.arange(nt, dtype=float) * dt_days,
+                    dtype=float,
+                )
             else:
-                jds = Time(jd_center, format="jd") + np.arange(
-                    -(nt // 2), nt // 2 + nt % 2
-                ) * (dt * units.s).to("d")
-            jds = jds.jd
+                assert jd_center is not None
+                dt_days = (
+                    float(cast(Any, dt).to_value(units.d))
+                    if isinstance(dt, Quantity)
+                    else float(cast(Any, Quantity(float(dt), units.s).to_value(units.d)))
+                )
+                jd_center_val = float(cast(Any, Time(jd_center, format="jd")).jd)
+                jds = np.asarray(
+                    jd_center_val
+                    + np.arange(-(nt // 2), nt // 2 + nt % 2, dtype=float) * dt_days,
+                    dtype=float,
+                )
+            df = float(channel_width_hz)
+            dt = (
+                float(cast(Any, dt).to_value(units.s))
+                if isinstance(dt, Quantity)
+                else float(dt)
+            )
 
         elif data_path.suffix in [".uvh5", ".uvfits", ".ms"]:
             mpiprint(
@@ -1420,36 +1675,47 @@ def get_vis_data(
                     return_uvd=True,
                     save_vis=save_vis,
                     save_model=save_model,
-                    save_dir=save_dir,
+                    save_dir=str(save_dir),
                     clobber=clobber,
                     verbose=verbose,
                     rank=rank,
                 )
             )
+            vis = cast(ComplexArray, vis)
+            uvws = cast(FloatArray, uvws)
+            redundancy = cast(FloatArray, redundancy)
+            if noise is not None:
+                noise = cast(ComplexArray, noise)
+            if phasor is not None:
+                phasor = cast(ComplexArray, phasor)
+            assert uvd is not None
             # Check if the frequency array has the Nspws axis for
             # backwards compatibility with old versions of pyuvdata
             trim_nspws_ax = len(uvd.freq_array.shape) > 1
-            freqs = uvd.freq_array
+            freqs = np.asarray(uvd.freq_array, dtype=float)
             if trim_nspws_ax:
                 freqs = freqs[0]
-            df = freqs[1] - freqs[0]
+            df = float(freqs[1] - freqs[0])
             nf = freqs.size
 
-            jds = Time(np.unique(uvd.time_array), format="jd")
-            dt = (jds[1] - jds[0]).to("s").value
-            jds = jds.jd
+            jds = np.asarray(np.unique(uvd.time_array), dtype=float)
+            assert jds.size > 1
+            dt = float((jds[1] - jds[0]) * 86400.0)
             nt = jds.size
 
             try:
                 # Old versions of pyuvdata use telescope_name atribute which
                 # has been replaced by telescope.name in newer versions
-                tele_name = uvd.telescope_name
-            except:
+                tele_name = cast(Any, uvd).telescope_name
+            except AttributeError:
                 tele_name = uvd.telescope.name
 
         if simulate_noise:
             mpiprint("\nGenerating visibility noise:", style="bold", rank=rank)
             mpiprint(f"\nNoise std. dev. = {sigma:.2e} mK sr", rank=rank)
+            assert sigma is not None
+            assert nf is not None
+            assert nt is not None
             vis_noisy, noise, bl_conj_pairs_map = generate_gaussian_noise(
                 sigma,
                 vis,
@@ -1457,23 +1723,29 @@ def get_vis_data(
                 nt,
                 uvws[0],
                 redundancy[0],
-                random_seed=noise_seed,
+                random_seed=noise_seed if noise_seed is not None else "",
                 rank=print_rank,
             )
+            vis_noisy = cast(ComplexArray, vis_noisy)
+            noise = cast(ComplexArray, noise)
         else:
             # The input visibilities are noisy
             vis_noisy = vis
+            bl_conj_pairs_map = np.arange(vis_noisy.size, dtype=int)
 
-        vis_dict = {
-            "vis_noisy": vis_noisy,
-            "noise": noise,
-            "bl_conj_pairs_map": bl_conj_pairs_map,
-            "uvws": uvws,
-            "redundancy": redundancy,
-            "freqs": freqs,
-            "df": df,
-            "jds": jds,
-            "dt": dt,
+        assert noise is not None
+        df_float = float(cast(Any, df))
+        dt_float = float(cast(Any, dt))
+        vis_dict: VisibilityData = {
+            "vis_noisy": cast(ComplexArray, vis_noisy),
+            "noise": cast(ComplexArray, noise),
+            "bl_conj_pairs_map": np.asarray(bl_conj_pairs_map, dtype=int),
+            "uvws": cast(FloatArray, uvws),
+            "redundancy": cast(FloatArray, redundancy),
+            "freqs": np.asarray(freqs, dtype=float),
+            "df": df_float,
+            "jds": np.asarray(jds, dtype=float),
+            "dt": dt_float,
         }
         if simulate_noise:
             vis_dict["vis"] = vis
@@ -1570,8 +1842,6 @@ def build_k_cube(
             "and ps_box_size_para_Mpc must all not be None"
         )
 
-    # print_rank will only trigger print if verbose is True and rank == 0
-    print_rank = 1 - (verbose and rank == 0)
     mod_k, _, _, _, _, _, _ = generate_k_cube_in_physical_coordinates(
         nu,
         nv,
@@ -1588,7 +1858,7 @@ def build_k_cube(
         mod_k_vo,
         k_cube_voxels_in_bin,
         save_k_vals=(save_k_vals and rank == 0),
-        k_vals_dir=output_dir,
+        k_vals_dir=str(output_dir),
         clobber=clobber,
     )
 
@@ -1626,7 +1896,7 @@ def generate_array_dir(
     dt: float | None = None,
     drift_scan: bool = True,
     beam_type: str | None = None,
-    beam_center: list[float] | None = None,
+    beam_center: Sequence[float] | None = None,
     achromatic_beam: bool = False,
     beam_peak_amplitude: float | None = 1.0,
     fwhm_deg: float | None = None,
@@ -1780,10 +2050,13 @@ def generate_array_dir(
         model_str += "-ffm"
     if use_shg:
         shg_str = "shg"
+        assert nu_sh is not None
         if nu_sh > 0:
             shg_str += f"-nush{nu_sh}"
+        assert nv_sh is not None
         if nv_sh > 0 and nu_sh != nv_sh:
             shg_str += f"-nvsh{nv_sh}"
+        assert nq_sh is not None
         if nq_sh > 0:
             shg_str += f"-nqsh{nq_sh}"
         if fit_for_shg_amps:
@@ -1818,6 +2091,9 @@ def generate_array_dir(
     matrices_path /= img_str
 
     if include_instrumental_effects:
+        assert nt is not None
+        assert dt is not None
+        assert beam_type is not None
         inst_str = ""
         if telescope_name != "":
             inst_str += f"{telescope_name}-"
@@ -1919,7 +2195,7 @@ def build_matrices(
     jd_center: float,
     dt: float,
     beam_type: str,
-    beam_center: list[float] | None = None,
+    beam_center: Sequence[float] | None = None,
     achromatic_beam: bool = False,
     beam_peak_amplitude: float = 1.0,
     fwhm_deg: float | None = None,
@@ -1930,7 +2206,7 @@ def build_matrices(
     telescope_name: str = "",
     uvws: np.ndarray,
     redundancy: np.ndarray,
-    noise: np.ndarray,
+    noise: np.ndarray | None,
     phasor: np.ndarray | None = None,
     taper_func: str | None = None,
     noise_data_path: Path | str | None = None,
@@ -2131,20 +2407,10 @@ def build_matrices(
             "telescope_latlonalt cannot be None if include_instrumental_effects is true"
         )
 
-    # print_rank will only trigger print if verbose is True and rank == 0
-    print_rank = 1 - (verbose and rank == 0)
-
     if uvws is not None:
         nbls = len(uvws[0])
-        uvws_vec = uvws.copy().reshape(-1, 3)
-        n_vis = len(uvws_vec)
     else:
         nbls = None
-        uvws_vec = None
-        n_vis = None
-
-    if redundancy is not None:
-        redundancy_vec = redundancy.copy().reshape(-1, 1).flatten()
 
     array_dir = generate_array_dir(
         nu=nu,
@@ -2297,7 +2563,7 @@ def build_posterior(
     ps_box_size_dec_Mpc: float,
     ps_box_size_para_Mpc: float,
     include_instrumental_effects: bool = True,
-    priors: Sequence[float],
+    priors: Sequence[Sequence[float]],
     log_priors: bool = False,
     uprior_inds: np.ndarray | None = None,
     dimensionless_PS: bool = True,
@@ -2417,6 +2683,7 @@ def build_posterior(
     # The EoR model uv-plane excludes the (u, v) = (0, 0) pixel, so the number
     # of EoR model uv-plane pixels is nu*nv - 1
     nuv = nu * nv - 1
+    prior_list = [list(prior) for prior in priors]
 
     if use_LWM_Gaussian_prior:
         # use_LWM_Gaussian_prior not implemented
@@ -2436,21 +2703,21 @@ def build_posterior(
         # constraint at the given signal-to-noise in the data.
         fg_log_priors_max = 6.0
         # Calibrate LW model priors using white noise fitting
-        priors[0] = [fg_log_priors_min, fg_log_priors_max]
-        priors[1] = [fg_log_priors_min, fg_log_priors_max]
-        priors[2] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[0] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[1] = [fg_log_priors_min, fg_log_priors_max]
+        prior_list[2] = [fg_log_priors_min, fg_log_priors_max]
         if use_intrinsic_noise_fitting:
-            priors[1] = priors[0]
-            priors[2] = priors[1]
-            priors[3] = priors[2]
-            priors[0] = [1.0, 2.0]  # Linear alpha_prime range
+            prior_list[1] = prior_list[0]
+            prior_list[2] = prior_list[1]
+            prior_list[3] = prior_list[2]
+            prior_list[0] = [1.0, 2.0]  # Linear alpha_prime range
     else:
         if use_intrinsic_noise_fitting:
-            priors[0] = [1.0, 2.0]  # Linear alpha_prime range
+            prior_list[0] = [1.0, 2.0]  # Linear alpha_prime range
     ps_unit = "mK^2"
     if not dimensionless_PS:
         ps_unit += " Mpc^3"
-    mpiprint(f"priors = {priors} {ps_unit}", rank=print_rank)
+    mpiprint(f"priors = {prior_list} {ps_unit}", rank=print_rank)
 
     pspp = PowerSpectrumPosteriorProbability(
         T_Ninv_T,

--- a/bayeseor/utils.py
+++ b/bayeseor/utils.py
@@ -4,20 +4,30 @@ import pickle
 import shutil
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Any, Optional, Protocol, cast
 
 import numpy as np
-from mpi4py import MPI
 from rich.console import Console
-
-if TYPE_CHECKING:
-    from mpi4py import MPI
 
 
 from . import __version__
 
 cns = Console()
 cns.is_jupyter = False
+
+
+class MPIComm(Protocol):
+    def Get_rank(self) -> int: ...
+
+    def bcast(self, value: Any, root: int = 0) -> Any: ...
+
+    def Barrier(self) -> None: ...
+
+
+def _get_default_mpi_comm() -> MPIComm:
+    from mpi4py import MPI
+
+    return cast(MPIComm, MPI.COMM_WORLD)
 
 
 def mpiprint(*args, rank=0, highlight=False, soft_wrap=True, **kwargs):
@@ -145,7 +155,7 @@ def save_numpy_dict(
     if extra is not None:
         out_dict.update({"extra": extra})
 
-    np.save(fp, out_dict)
+    np.save(fp, np.array(out_dict, dtype=object))
 
 
 def load_numpy_dict(fp):
@@ -264,7 +274,7 @@ class ShortTempPathManager:
         self,
         output_dir: str | Path,
         tmp_dir: str | Path | None = None,
-        mpi_comm: Optional[MPI.Comm] = None,
+        mpi_comm: Optional[MPIComm] = None,
     ) -> None:
         """
         Initialise the ShortTempPathManager and create the symbolic link.
@@ -300,7 +310,7 @@ class ShortTempPathManager:
         if tmp_dir is None:
             tmp_dir = "./.mn_chains_symlinks/"
         self.tmp_dir: Path = Path(tmp_dir)
-        self.mpi_comm: MPI.Comm = mpi_comm or MPI.COMM_WORLD
+        self.mpi_comm: MPIComm = mpi_comm or _get_default_mpi_comm()
         self.mpi_rank: int = self.mpi_comm.Get_rank()
 
         # Generate the short path using a stronger hash to reduce collision risk
@@ -469,7 +479,7 @@ class MultiNestPathManager:
     """
 
     def __init__(
-        self, out_dir: Path, rank: int, mpi_comm: Optional["MPI.Comm"] = None
+        self, out_dir: Path, rank: int, mpi_comm: Optional[MPIComm] = None
     ):
         """
         Initializes the MultiNestPathManager.

--- a/bayeseor/utils.py
+++ b/bayeseor/utils.py
@@ -118,9 +118,7 @@ def write_log_files(parser, args, out_dir=Path("./"), verbose=False):
         print(f"Log files written successfully to {out_dir.absolute()}\n")
 
 
-def save_numpy_dict(
-    fp, arr, args, version=__version__, extra=None, clobber=False
-):
+def save_numpy_dict(fp, arr, args, version=__version__, extra=None, clobber=False):
     """
     Save array to disk with metadata as dictionary.
 
@@ -358,9 +356,9 @@ class ShortTempPathManager:
         try:
             resolved = path.resolve()
             tmp_resolved = self.tmp_dir.resolve()
-            return str(resolved) == str(tmp_resolved) or str(
-                resolved
-            ).startswith(str(tmp_resolved) + os.sep)
+            return str(resolved) == str(tmp_resolved) or str(resolved).startswith(
+                str(tmp_resolved) + os.sep
+            )
         except Exception:
             return False
 
@@ -478,9 +476,7 @@ class MultiNestPathManager:
     ```
     """
 
-    def __init__(
-        self, out_dir: Path, rank: int, mpi_comm: Optional[MPIComm] = None
-    ):
+    def __init__(self, out_dir: Path, rank: int, mpi_comm: Optional[MPIComm] = None):
         """
         Initializes the MultiNestPathManager.
 
@@ -499,9 +495,7 @@ class MultiNestPathManager:
         # Step 1.
         self.long_out_dir = out_dir
         # Step 2a.
-        self.short_path_manager = ShortTempPathManager(
-            out_dir, mpi_comm=mpi_comm
-        )
+        self.short_path_manager = ShortTempPathManager(out_dir, mpi_comm=mpi_comm)
         # Step 2b.
         self.short_out_dir = self.short_path_manager.short_out_dir
 

--- a/bayeseor/vis.py
+++ b/bayeseor/vis.py
@@ -2,10 +2,12 @@ import numpy as np
 from astropy import units
 from astropy.units import Quantity
 from astropy.time import Time
+from numpy.typing import NDArray
 from pathlib import Path
 from pyuvdata import __version__ as pyuvdata_version
 from pyuvdata import UVData
 from pyuvdata.utils import polstr2num
+from typing import Any, cast
 import warnings
 
 from .model.healpix import Healpix
@@ -30,7 +32,7 @@ def preprocess_uvdata(
     redundant_avg=False,
     uniform_redundancy=False,
     phase=False,
-    phase_time=False,
+    phase_time: Time | float | None = None,
     calc_noise=False,
     return_uvd=False,
     save_vis=False,
@@ -203,17 +205,19 @@ def preprocess_uvdata(
     mpiprint(f"\nReading data from: {fp}", rank=rank)
     uvd.read(fp, read_data=False)
     uvd.select(ant_str=ant_str)
+    uvd_vis_units = cast(str, getattr(uvd, "vis_units"))
+    freq_array = np.asarray(uvd.freq_array, dtype=float)
 
-    if uvd.vis_units not in ["Jy", "K str"]:
+    if uvd_vis_units not in ["Jy", "K str"]:
         raise ValueError(
             "This code requires calibrated input visibilities in units of "
             "Janskys or kelvin steradians. The input UVData object has "
-            f"incompatible units of {uvd.vis_units}."
+            f"incompatible units of {uvd_vis_units}."
         )
 
     # Check if the frequency array has the Nspws axis for
     # backwards compatibility with old versions of pyuvdata
-    trim_nspws_ax = len(uvd.freq_array.shape) > 1
+    trim_nspws_ax = freq_array.ndim > 1
 
     if bl_cutoff is not None:
         if not isinstance(bl_cutoff, Quantity):
@@ -222,9 +226,10 @@ def preprocess_uvdata(
             f"\nBaseline downselect: keeping |b| <= {bl_cutoff} m",
             rank=print_rank
         )
+        uvw_array = np.asarray(uvd.uvw_array, dtype=float)
         bl_lengths = Quantity(
-            np.sqrt(np.sum(uvd.uvw_array[:, :2]**2, axis=1)),
-            unit="m"
+            np.sqrt(np.sum(uvw_array[:, :2] ** 2, axis=1)),
+            unit="m",
         )
         blt_inds = np.where(bl_lengths <= bl_cutoff)[0]
         mpiprint(f"\tBaselines before length select: {uvd.Nbls}", rank=print_rank)
@@ -234,34 +239,32 @@ def preprocess_uvdata(
     
     # Frequency downselect
     if np.any([param is not None for param in [freq_min, freq_idx_min, freq_center]]):
-        freqs = Quantity(uvd.freq_array, unit="Hz")
-        if trim_nspws_ax:
-            freqs = freqs[0]
+        freqs_hz = np.asarray(freq_array[0] if trim_nspws_ax else freq_array, dtype=float)
         if freq_center is not None:
             if Nfreqs is None:
                 raise ValueError("Must pass Nfreqs with freq_center")
             if not isinstance(freq_center, Quantity):
                 freq_center = Quantity(freq_center, unit="Hz")
-            if freq_center.to("Hz") < freqs[0].to("Hz"):
+            freq_center = cast(Quantity, freq_center)
+            freq_center_hz = float(cast(Any, freq_center).to_value("Hz"))
+            if freq_center_hz < float(freqs_hz[0]):
                 raise ValueError(
                     f"freq_center ({freq_center.to('MHz')}) < minimum frequency "
-                    f"in data ({freqs[0].to('MHz')})"
+                    f"in data ({Quantity(freqs_hz[0], 'Hz').to('MHz')})"
                 )
-            if freq_center.to("Hz") > freqs[-1].to("Hz"):
+            if freq_center_hz > float(freqs_hz[-1]):
                 raise ValueError(
                     f"freq_center ({freq_center.to('MHz')}) > maximum frequency "
-                    f"in data ({freqs[-1].to('MHz')})"
+                    f"in data ({Quantity(freqs_hz[-1], 'Hz').to('MHz')})"
                 )
-            freq_idx_center = np.argmin(
-                np.abs(freqs.to("Hz") - freq_center.to("Hz"))
-            )
+            freq_idx_center = int(np.argmin(np.abs(freqs_hz - freq_center_hz)))
             if freq_idx_center - (Nfreqs//2) < 0:
                 raise ValueError(
                     f"Invalid combination of freq_center ({freq_center}) "
                     f"and Nfreqs ({Nfreqs}).  There are fewer than Nfreqs//2 "
                     "frequencies less than or equal to freq_center."
                 )
-            if freq_idx_center + Nfreqs//2 > freqs.size:
+            if freq_idx_center + Nfreqs//2 > freqs_hz.size:
                 warnings.warn(
                     "There are less than Nfreqs//2 frequencies "
                     "greater than or equal to freq_center.  This combination "
@@ -275,87 +278,94 @@ def preprocess_uvdata(
                 rank=print_rank
             )
             freq_idx_min = freq_idx_center - (Nfreqs//2)
-            freq_min = freqs[freq_idx_min]
+            freq_min_hz = float(freqs_hz[freq_idx_min])
         elif freq_min is not None:
             if not isinstance(freq_min, Quantity):
                 freq_min = Quantity(freq_min, unit="Hz")
-            if freq_min.to("Hz") < freqs[0].to("Hz"):
+            freq_min = cast(Quantity, freq_min)
+            freq_min_hz = float(cast(Any, freq_min).to_value("Hz"))
+            if freq_min_hz < float(freqs_hz[0]):
                 warnings.warn(
                     f"freq_min ({freq_min.to('MHz')}) < minimum frequency "
-                    f"in data ({freqs[0].to('MHz')}).  All frequencies will "
+                    f"in data ({Quantity(freqs_hz[0], 'Hz').to('MHz')}).  All frequencies will "
                     "kept in the data vector if Nfreqs is not specified."
                 )
-            if freq_min.to("Hz") > freqs[-1].to("Hz"):
+            if freq_min_hz > float(freqs_hz[-1]):
                 raise ValueError(
                     f"freq_min ({freq_min.to('MHz')}) > maximum frequency "
-                    f"in data ({freqs[-1].to('MHz')})"
+                    f"in data ({Quantity(freqs_hz[-1], 'Hz').to('MHz')})"
                 )
-            freq_idx_min = np.where(freqs.to("Hz") >= freq_min.to("Hz"))[0][0]
+            freq_idx_min = int(np.where(freqs_hz >= freq_min_hz)[0][0])
         else:
+            assert freq_idx_min is not None
             if freq_idx_min < 0:
                 raise ValueError("freq_idx_min must be positive")
-            if freq_idx_min >= freqs.size:
+            if freq_idx_min >= freqs_hz.size:
                 raise ValueError(
                     "freq_idx_min cannot exceed the number of "
                     "frequencies in the data"
                 )
-            freq_min = freqs[freq_idx_min]
+            freq_min_hz = float(freqs_hz[freq_idx_min])
+        assert freq_idx_min is not None
         if Nfreqs is None:
-            Nfreqs = freqs.size - freq_idx_min
+            Nfreqs = int(freqs_hz.size - freq_idx_min)
         else:
             if Nfreqs <= 0:
                 raise ValueError("Nfreqs must be positive")
         if freq_center is None:
+            assert freq_min_hz is not None
             mpiprint(
                 f"\nFrequency downselect: keeping {Nfreqs} frequencies "
-                + f">= {freq_min.to('MHz'):.2f}",
+                + f">= {Quantity(freq_min_hz, 'Hz').to_value('MHz'):.2f} MHz",
                 rank=print_rank
             )
-        if Nfreqs > freqs[freq_idx_min : freq_idx_min+Nfreqs].size:
+        selected_freqs_hz = freqs_hz[freq_idx_min : freq_idx_min+Nfreqs]
+        if Nfreqs > selected_freqs_hz.size:
             warnings.warn(
                 "this combination of freq_min or freq_idx_min and "
                 "Nfreqs will result in fewer than Nfreqs frequencies being "
                 "kept in the data vector."
             )
-        freqs = freqs[freq_idx_min : freq_idx_min+Nfreqs]
+        freqs = np.asarray(selected_freqs_hz, dtype=float)
         mpiprint(f"\tNfreqs before frequency select: {uvd.Nfreqs}", rank=print_rank)
         mpiprint(f"\tNfreqs after frequency select:  {freqs.size}", rank=print_rank)
         mpiprint(
-            f"\tMinimum frequency in data vector: {freqs[0].to('MHz'):.2f}",
+            f"\tMinimum frequency in data vector: {Quantity(freqs[0], 'Hz').to_value('MHz'):.2f}",
             rank=print_rank
         )
         mpiprint(
             "\tCentral frequency in data vector: "
-            + f"{freqs[freqs.size//2].to('MHz'):.2f}",
+            + f"{Quantity(freqs[freqs.size//2], 'Hz').to_value('MHz'):.2f}",
             rank=print_rank
         )
         mpiprint(
-            f"\tMaximum frequency in data vector: {freqs[-1].to('MHz'):.2f}",
+            f"\tMaximum frequency in data vector: {Quantity(freqs[-1], 'Hz').to_value('MHz'):.2f}",
             rank=print_rank
         )
-        freqs = freqs.to("Hz").value
     else:
         freqs = None
     
     # Time downselect
     if np.any([param is not None for param in [jd_min, jd_idx_min, jd_center]]):
-        jds = Time(np.unique(uvd.time_array), format="jd")
+        jds = np.unique(np.asarray(uvd.time_array, dtype=float))
         if jd_center is not None:
             if Ntimes is None:
                 raise ValueError("Must pass Ntimes with jd_center")
             if not isinstance(jd_center, Time):
                 jd_center = Time(jd_center, format="jd")
-            if jd_center.jd < jds[0].jd:
+            jd_center = cast(Time, jd_center)
+            jd_center_value = float(cast(Any, jd_center).jd)
+            if jd_center_value < float(jds[0]):
                 raise ValueError(
                     f"jd_center ({jd_center.jd}) < minimum time "
-                    f"in data ({jds[0].jd})"
+                    f"in data ({jds[0]})"
                 )
-            if jd_center.jd > jds[-1].jd:
+            if jd_center_value > float(jds[-1]):
                 raise ValueError(
                     f"jd_center ({jd_center.jd}) > maximum time "
-                    f"in data ({jds[-1].jd})"
+                    f"in data ({jds[-1]})"
                 )
-            jd_idx_center = np.argmin(np.abs(jds.jd - jd_center.jd))
+            jd_idx_center = int(np.argmin(np.abs(jds - jd_center_value)))
             if jd_idx_center - (Ntimes//2) < 0:
                 raise ValueError(
                     f"Invalid combination of jd_center ({jd_center}) and "
@@ -376,54 +386,59 @@ def preprocess_uvdata(
                 rank=print_rank
             )
             jd_idx_min = jd_idx_center - (Ntimes//2)
-            jd_min = jds[jd_idx_min]
+            jd_min_value = float(jds[jd_idx_min])
         elif jd_min is not None:
             if not isinstance(jd_min, Time):
                 jd_min = Time(jd_min, format="jd")
-            if jd_min.jd < jds[0].jd:
+            jd_min = cast(Time, jd_min)
+            jd_min_value = float(cast(Any, jd_min).jd)
+            if jd_min_value < float(jds[0]):
                 warnings.warn(
-                    f"jd_min ({jd_min.jd}) < minimum time in data ({jds[0].jd}). "
+                    f"jd_min ({jd_min.jd}) < minimum time in data ({jds[0]}). "
                     "All times will be kept in the data vector if Ntimes is "
                     "not specified."
                 )
-            if jd_min.jd > jds[-1].jd:
+            if jd_min_value > float(jds[-1]):
                 raise ValueError(
-                    f"jd_min ({jd_min.jd}) > maximum time in data ({jds[-1].jd})"
+                    f"jd_min ({jd_min.jd}) > maximum time in data ({jds[-1]})"
                 )
-            jd_idx_min = np.where(jds.jd >= jd_min.jd)[0][0]
+            jd_idx_min = int(np.where(jds >= jd_min_value)[0][0])
         else:
+            assert jd_idx_min is not None
             if jd_idx_min < 0:
                 raise ValueError("jd_idx_min must be positive")
             if jd_idx_min >= jds.size:
                 raise ValueError(
                     "jd_idx_min cannot exceed the number of times in the data"
                 )
-            jd_min = jds[jd_idx_min]
+            jd_min_value = float(jds[jd_idx_min])
+        assert jd_idx_min is not None
         if Ntimes is None:
-            Ntimes = jds.size - jd_idx_min
+            Ntimes = int(jds.size - jd_idx_min)
         else:
             if Ntimes <= 0:
                 raise ValueError("Ntimes must be positive")
         if jd_center is None:
+            assert jd_min_value is not None
             mpiprint(
-                f"\nTime downselect: keeping {Ntimes} times >= {jd_center}",
+                f"\nTime downselect: keeping {Ntimes} times >= {jd_min_value}",
                 rank=print_rank
             )
-        if Ntimes > jds[jd_idx_min : jd_idx_min+Ntimes].size:
+        selected_jds = jds[jd_idx_min : jd_idx_min+Ntimes]
+        if Ntimes > selected_jds.size:
             warnings.warn(
                 "this combination of jd_min or jd_idx_min and Ntimes "
                 "will result in fewer than Ntimes times being kept in the "
                 "data vector."
             )
-        jds = jds[jd_idx_min : jd_idx_min+Ntimes]
+        jds = np.asarray(selected_jds, dtype=float)
         mpiprint(f"\tNtimes before time select: {uvd.Ntimes}", rank=print_rank)
         mpiprint(f"\tNtimes after time select:  {jds.size}", rank=print_rank)
-        mpiprint(f"\tMinimum time in data vector: {jds[0].jd}", rank=print_rank)
+        mpiprint(f"\tMinimum time in data vector: {jds[0]}", rank=print_rank)
         mpiprint(
-            f"\tCentral time in data vector: {jds[jds.size//2].jd}", rank=print_rank
+            f"\tCentral time in data vector: {jds[jds.size//2]}", rank=print_rank
         )
-        mpiprint(f"\tMaximum time in data vector: {jds[-1].jd}", rank=print_rank)
-        jds = jds.jd
+        mpiprint(f"\tMaximum time in data vector: {jds[-1]}", rank=print_rank)
     else:
         jds = None
 
@@ -455,13 +470,13 @@ def preprocess_uvdata(
         uvd = form_pI_vis(uvd, norm=pI_norm)
         pol = "pI"
     else:
-        if not polstr2num(pol) in uvd.polarization_array:
+        if polstr2num(pol) not in uvd.polarization_array:
             raise ValueError(
                 f"Polarization {pol} not present in uvd.polarization_array"
             )
         uvd.select(polarizations=[pol])
     
-    if uvd.vis_units == "K str":
+    if uvd_vis_units == "K str":
         uvd.data_array *= 1e3
     else:
         if trim_nspws_ax:
@@ -506,13 +521,15 @@ def preprocess_uvdata(
     # (u, v, w) coordinates instead of the phasor vector.
     uvws = np.zeros((uvd.Ntimes, Nbls_vec, 3), dtype=float)
     redundancy = np.ones((uvd.Ntimes, Nbls_vec, 1), dtype=float)
+    uvw_array = np.asarray(uvd.uvw_array, dtype=float)
     for i_bl, antpair in enumerate(antpairs):
         uvw_ind = uvd.antpair2ind(antpair)
         if isinstance(uvw_ind, slice):
-            uvw_ind = uvw_ind.start
+            assert uvw_ind.start is not None
+            uvw_index = int(uvw_ind.start)
         else:
-            uvw_ind = uvw_ind[0]
-        uvw = uvd.uvw_array[uvw_ind]
+            uvw_index = int(np.asarray(uvw_ind).reshape(-1)[0])
+        uvw = uvw_array[uvw_index]
         uvws[:, i_bl] = uvw
         uvws[:, Nbls+i_bl] = -1*uvw
         if redundant_avg and not uniform_redundancy:
@@ -561,7 +578,7 @@ def preprocess_uvdata(
         )
         extra = dict(pyuvdata_version=pyuvdata_version)
     if save_vis:
-        mpiprint(f"\nSaving data vector(s) to disk:", rank=print_rank)
+        mpiprint("\nSaving data vector(s) to disk:", rank=print_rank)
         mpiprint(f"\tVisibility vector: {vis_path}", rank=print_rank)
         save_numpy_dict(vis_path, vis, args, extra=extra, clobber=clobber)
         if calc_noise:
@@ -570,7 +587,7 @@ def preprocess_uvdata(
                 noise_path, noise, args, extra=extra, clobber=clobber
             )
     if save_model:
-        mpiprint(f"\nSaving instrument model to disk:", rank=print_rank)
+        mpiprint("\nSaving instrument model to disk:", rank=print_rank)
         mpiprint(f"\tAntpairs: {ants_path}", rank=print_rank)
         save_numpy_dict(
             ants_path, antpairs, args, extra=extra, clobber=clobber
@@ -599,11 +616,11 @@ def uvd_to_vector(
     antpairs,
     pol="xx",
     phase=False,
-    phase_time=False,
+    phase_time: Time | float | None = None,
     calc_noise=False,
     verbose=False,
     rank=0
-):
+) -> tuple[NDArray[np.complex128], NDArray[np.complex128] | None, NDArray[np.complex128] | None]:
     """
     Form a one-dimensional data vector from a pyuvdata.UVData object.
 
@@ -668,16 +685,21 @@ def uvd_to_vector(
         uvd_phasor.data_array = np.ones_like(uvd_phasor.data_array)
 
         jds = Time(np.unique(uvd.time_array), format="jd")
+        jd_min = jds[0]
+        jd_max = jds[-1]
+        assert isinstance(jd_min, Time)
+        assert isinstance(jd_max, Time)
         if phase_time is not None:
             if not isinstance(phase_time, Time):
                 phase_time = Time(phase_time, format="jd")
-            if phase_time.jd < jds[0].jd:
+            assert isinstance(phase_time, Time)
+            if phase_time.jd < jd_min.jd:
                 warnings.warn(
-                    f"phase_time ({phase_time}) < minimum time in data ({jds[0]})"
+                    f"phase_time ({phase_time}) < minimum time in data ({jd_min})"
                 )
-            if phase_time.jd > jds[-1].jd:
+            if phase_time.jd > jd_max.jd:
                 warnings.warn(
-                    f"phase_time ({phase_time}) > maximum time in data ({jds[-1]})"
+                    f"phase_time ({phase_time}) > maximum time in data ({jd_max})"
                 )
         else:
             warnings.warn(
@@ -685,11 +707,12 @@ def uvd_to_vector(
                 "the central time step."
             )
             phase_time = jds[jds.size//2]
+        assert isinstance(phase_time, Time)
         mpiprint(f"Phasing data to time {phase_time}", rank=print_rank)
         uvd_phasor.phase_to_time(phase_time)
 
     if calc_noise:
-        mpiprint(f"\nEstimating noise", rank=print_rank)
+        mpiprint("\nEstimating noise", rank=print_rank)
         uvd_noise = uvd.copy()
         for antpair in antpairs:
             vis = uvd_noise.get_data(antpair + (pol,), force_copy=True)
@@ -730,7 +753,7 @@ def uvd_to_vector(
     # at the 0th time.
     Nbls = uvd.Nbls
     Nbls_vec = 2*Nbls
-    mpiprint(f"\nForming data vector(s)", rank=print_rank)
+    mpiprint("\nForming data vector(s)", rank=print_rank)
     for i_bl, antpair in enumerate(antpairs):
         antpairpol = antpair + (pol,)
         vis = uvd.get_data(antpairpol)
@@ -745,16 +768,9 @@ def uvd_to_vector(
             noise_vec[i_bl :: Nbls_vec] = noise.flatten()
             noise_vec[Nbls+i_bl :: Nbls_vec] = noise.flatten().conj()
 
-    return_vals = (vis_vec,)
-    if phase:
-        return_vals += (phasor_vec,)
-    else:
-        return_vals += (None,)
-    if calc_noise:
-        return_vals += (noise_vec,)
-    else:
-        return_vals += (None,)
-    return return_vals
+    phasor_out = phasor_vec if phase else None
+    noise_out = noise_vec if calc_noise else None
+    return (vis_vec, phasor_out, noise_out)
 
 def form_pI_vis(uvd, norm=1.0):
     """
@@ -788,7 +804,11 @@ def form_pI_vis(uvd, norm=1.0):
 
     return uvd
 
-def jy_to_ksr(data, freqs, mK=False):
+def jy_to_ksr(
+    data: NDArray[np.complex128] | NDArray[np.float64],
+    freqs: Quantity | NDArray[np.float64],
+    mK: bool = False,
+) -> NDArray[np.complex128] | NDArray[np.float64]:
     """
     Convert visibilities from units of Janskys to kelvin steradians.
 
@@ -817,10 +837,17 @@ def jy_to_ksr(data, freqs, mK=False):
         temp_unit = units.mK
     else:
         temp_unit = units.K
-    conv_factor = (1*units.Jy).to(temp_unit, equivalencies=equiv)
-    conv_factor *= units.sr / units.Jy
+    conversion_unit = cast(Any, temp_unit * units.sr / units.Jy)
+    conv_factor = Quantity(
+        Quantity(1.0, unit=units.Jy).to_value(temp_unit, equivalencies=equiv),
+        unit=conversion_unit,
+    )
+    conv_factor_values: NDArray[np.float64] = np.asarray(
+        conv_factor.to_value(conversion_unit),
+        dtype=float,
+    )
 
-    return data * conv_factor[np.newaxis, :].value
+    return data * conv_factor_values[np.newaxis, :]
 
 def mock_data_from_eor_cube(
     nu,
@@ -870,6 +897,7 @@ def mock_data_from_eor_cube(
 
     """
     mpiprint("Using use_EoR_cube data", rank=rank)
+    assert eor_npz_path is not None, "eor_npz_path must not be None."
     eor_cube = np.load(eor_npz_path)["arr_0"]
 
     axes_tuple = (1, 2)
@@ -957,14 +985,14 @@ def generate_mock_eor_signal_instrumental(
     """
     mpiprint("Generating white noise sky signal...", rank=rank)
     hpx = Healpix(
-        fov_ra_deg=fov_ra_deg,
-        fov_dec_deg=fov_dec_deg,
+        fov_ra_eor=fov_ra_deg,
+        fov_dec_eor=fov_dec_deg,
         nside=nside,
         telescope_latlonalt=telescope_latlonalt,
-        central_jd=central_jd,
+        jd_center=central_jd,
         nt=nt,
-        int_time=int_time,
-        beam_type=beam_type
+        dt=int_time,
+        beam_type=beam_type,
     )
     # RMS scaled to hold the power spectrum amplitude constant
     wn_rms *= nside / 256

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,12 +11,13 @@ dependencies:
   - magma
   - matplotlib
   - mpi4py>=3.0.0
-  - numpy==2.2.6
+  - numpy>=1.26,<2
   - pip
+  - pre-commit
   - pycuda
   - pymultinest
   - pytest
-  - python==3.13
+  - python==3.12
   - pyuvdata
   - rich
   - ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,11 @@ doc = [
     "matplotlib"
 ]
 test = [
+    "matplotlib",
     "pytest"
 ]
 dev = [
+    "matplotlib",
     "pre-commit",
     "pytest",
     "ruff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-# requires-python = ">= 3.10"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.10,<3.13"
 
 dependencies = [
     "astropy",
@@ -36,6 +35,7 @@ test = [
     "pytest"
 ]
 dev = [
+    "pre-commit",
     "pytest",
     "ruff"
 ]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,13 +10,13 @@
   ],
   "venvPath": "/home/ps550/miniforge3/envs",
   "venv": "bayeseor",
-  "pythonVersion": "3.13",
+  "pythonVersion": "3.12",
   "typeCheckingMode": "basic",
   "executionEnvironments": [
     {
       "root": ".",
       "extraPaths": [
-        "/home/ps550/miniforge3/envs/bayeseor/lib/python3.13/site-packages"
+        "/home/ps550/miniforge3/envs/bayeseor/lib/python3.12/site-packages"
       ]
     }
   ]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,6 +8,16 @@
     "docs",
     "test_data"
   ],
+  "venvPath": "/home/ps550/miniforge3/envs",
+  "venv": "bayeseor",
   "pythonVersion": "3.13",
-  "typeCheckingMode": "basic"
+  "typeCheckingMode": "basic",
+  "executionEnvironments": [
+    {
+      "root": ".",
+      "extraPaths": [
+        "/home/ps550/miniforge3/envs/bayeseor/lib/python3.13/site-packages"
+      ]
+    }
+  ]
 }

--- a/scripts/precommit_check_yaml.py
+++ b/scripts/precommit_check_yaml.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+import sys
+
+import yaml
+
+
+def check_file(path: Path) -> bool:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            yaml.safe_load(handle)
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        print(f"YAML validation failed for {path}: {exc}")
+        return False
+    return True
+
+
+def main(paths: list[str]) -> int:
+    ok = True
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_file():
+            ok &= check_file(path)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/precommit_fix_end_of_file.py
+++ b/scripts/precommit_fix_end_of_file.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+import sys
+
+
+def fix_file(path: Path) -> bool:
+    try:
+        original = path.read_bytes()
+    except OSError:
+        return False
+
+    if b"\0" in original:
+        return False
+
+    stripped = original.rstrip(b"\r\n")
+    updated = stripped + b"\n"
+    if updated == original:
+        return False
+
+    path.write_bytes(updated)
+    print(f"Fixed end of file in {path}")
+    return True
+
+
+def main(paths: list[str]) -> int:
+    changed = False
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_file():
+            changed |= fix_file(path)
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/precommit_trim_trailing_whitespace.py
+++ b/scripts/precommit_trim_trailing_whitespace.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+import sys
+
+
+def trim_file(path: Path) -> bool:
+    try:
+        original = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+    lines = original.splitlines(keepends=True)
+    trimmed_lines: list[str] = []
+    for line in lines:
+        if line.endswith("\r\n"):
+            body = line[:-2]
+            ending = "\r\n"
+        elif line.endswith("\n"):
+            body = line[:-1]
+            ending = "\n"
+        else:
+            body = line
+            ending = ""
+        trimmed_lines.append(body.rstrip(" \t") + ending)
+
+    updated = "".join(trimmed_lines)
+    if updated == original:
+        return False
+
+    path.write_text(updated, encoding="utf-8")
+    print(f"Trimmed trailing whitespace in {path}")
+    return True
+
+
+def main(paths: list[str]) -> int:
+    changed = False
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_file():
+            changed |= trim_file(path)
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,142 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+from jsonargparse import Namespace
+from matplotlib.figure import Figure
+
+from bayeseor.analyze.analyze import DataContainer
+
+
+def _make_data_container(n_dirs: int = 1, n_kbins: int = 3) -> DataContainer:
+    container = object.__new__(DataContainer)
+    container.Ndirs = n_dirs
+    container.labels = None
+    container.k_vals_identical = True
+    base_k_vals = np.array([0.1, 0.2, 0.4], dtype=float)[:n_kbins]
+    container.k_vals = [base_k_vals.copy() for _ in range(n_dirs)]
+    container.k_vals_bins = [
+        np.array([0.05, 0.15, 0.3, 0.6], dtype=float)[: n_kbins + 1]
+        for _ in range(n_dirs)
+    ]
+    container.posteriors = [
+        np.array(
+            [[1.0, 2.0, 1.0], [0.8, 1.5, 0.8], [0.5, 1.0, 0.5]],
+            dtype=float,
+        )[:n_kbins]
+        for _ in range(n_dirs)
+    ]
+    container.posterior_bins = [
+        np.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.2, 0.4, 0.6, 0.8], [0.4, 0.8, 1.2, 1.6]],
+            dtype=float,
+        )[:n_kbins]
+        for _ in range(n_dirs)
+    ]
+    medians = np.array([1.0, 2.0, 4.0], dtype=float)[:n_kbins]
+    container.avgs = [medians.copy() for _ in range(n_dirs)]
+    container.medians = [medians.copy() for _ in range(n_dirs)]
+    container.cred_intervals = [
+        {
+            68: {
+                "lo": medians - 0.2,
+                "hi": medians + 0.3,
+            }
+        }
+        for _ in range(n_dirs)
+    ]
+    container.calc_uplims = True
+    container.uplims = [medians + 0.5 for _ in range(n_dirs)]
+    container.uplim_inds = None
+    container.calc_kurtosis = False
+    container.has_expected = np.bool_(True)
+    container.expected_ps = []
+    container.expected_dmps = [medians * 0.9 for _ in range(n_dirs)]
+    container.ps_kind = "dmps"
+    container.temp_unit = "mK"
+    container.k_units = "Mpc$^{-1}$"
+    container.ps_label = r"$\Delta^2(k)$"
+    container.ps_units = "mK$^2$"
+    container.args = [
+        Namespace(priors=[[-2.0, 1.0]] * n_kbins, log_priors=True)
+        for _ in range(n_dirs)
+    ]
+    return container
+
+
+def test_get_posterior_data_returns_optional_outputs(tmp_path):
+    container = object.__new__(DataContainer)
+    container.sampler = "multinest"
+    container.calc_uplims = True
+    container.calc_kurtosis = True
+
+    samples = np.array(
+        [
+            [0.25, 0.0, -1.0, 0.0],
+            [0.75, 0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    sample_path = tmp_path / "data-.txt"
+    np.savetxt(sample_path, samples)
+
+    out = container.get_posterior_data(
+        sample_path,
+        2,
+        posterior_weighted=True,
+        return_samples=True,
+    )
+
+    assert out[0].shape == (2, 31)
+    assert out[1].shape == (2, 32)
+    assert out[5] is not None and out[5].shape == (2,)
+    assert out[6] is not None and out[6].shape == (2,)
+    assert out[7] is not None and out[7].shape == (2, 4)
+
+
+def test_plot_power_spectra_defaults_uplims_and_returns_figure():
+    container = _make_data_container()
+
+    fig = container.plot_power_spectra()
+
+    assert isinstance(fig, Figure)
+    assert len(fig.axes) == 1
+    plt.close(fig)
+
+
+def test_plot_power_spectra_accepts_scalar_external_axis():
+    container = _make_data_container()
+    fig, ax = plt.subplots()
+
+    returned_axes = container.plot_power_spectra(fig=fig, axs=ax)
+
+    assert len(returned_axes) == 1
+    assert returned_axes[0] is ax
+    plt.close(fig)
+
+
+def test_plot_posteriors_accepts_scalar_external_axis():
+    container = _make_data_container(n_kbins=1)
+    fig, ax = plt.subplots()
+
+    returned_axes = container.plot_posteriors(fig=fig, axs=ax)
+
+    assert isinstance(returned_axes, list)
+    assert len(returned_axes) == 1
+    assert returned_axes[0] is ax
+    plt.close(fig)
+
+
+def test_plot_power_spectra_and_posteriors_smoke():
+    container = _make_data_container()
+
+    fig = container.plot_power_spectra_and_posteriors(
+        plot_diff=True,
+        uplim_inds=np.array([[False, True, False]], dtype=bool),
+    )
+
+    assert isinstance(fig, Figure)
+    assert len(fig.axes) >= 3
+    plt.close(fig)

--- a/tests/test_cosmology.py
+++ b/tests/test_cosmology.py
@@ -1,0 +1,60 @@
+import math
+from typing import Any, cast
+
+import astropy.units as u
+from astropy import constants as const
+from astropy.cosmology import Planck18
+
+from bayeseor.cosmology import Cosmology
+
+
+def test_f2z_and_z2f_are_consistent_for_float_frequency() -> None:
+    cosmology = Cosmology()
+    freq_hz = 150e6
+
+    z = cosmology.f2z(freq_hz)
+    recovered_freq_hz = cosmology.z2f(z)
+
+    assert math.isclose(recovered_freq_hz, freq_hz, rel_tol=1e-12)
+
+
+def test_f2z_accepts_astropy_quantity() -> None:
+    cosmology = Cosmology()
+    freq = 150 * u.MHz
+
+    z = cosmology.f2z(freq)
+    f_21_hz = float(cast(Any, 1420.40575177 * u.MHz).to_value(u.Hz))
+    freq_hz = float(cast(Any, freq).to_value(u.Hz))
+    expected = f_21_hz / freq_hz - 1.0
+
+    assert math.isclose(z, expected, rel_tol=1e-12)
+
+
+def test_distance_conversions_match_planck18() -> None:
+    cosmology = Cosmology()
+    z = 8.0
+
+    planck18 = cast(Any, Planck18)
+    expected_dldth = float(
+        cast(Any, planck18.comoving_transverse_distance(z)).to_value(u.Mpc)
+    )
+
+    assert math.isclose(cosmology.dL_dth(z), expected_dldth, rel_tol=1e-12)
+
+    # Reconstruct the expected dL/df using the same physical relation.
+    c_km_s = float(cast(Any, const.c).to_value(u.km / u.s))  # pyright: ignore
+    h0 = float(cast(Any, planck18.H0).to_value(u.km / (u.s * u.Mpc)))
+    e_z = float(planck18.efunc(z))
+    f21_hz = float(cast(Any, 1420.40575177 * u.MHz).to_value(u.Hz))
+    expected_dldf = c_km_s / h0 / e_z * (1 + z) ** 2 / f21_hz
+
+    assert math.isclose(cosmology.dL_df(z), expected_dldf, rel_tol=1e-12)
+
+
+def test_inst_to_cosmo_vol_is_product_of_component_conversions() -> None:
+    cosmology = Cosmology()
+    z = 8.0
+
+    expected = cosmology.dL_dth(z) ** 2 * cosmology.dL_df(z)
+
+    assert math.isclose(cosmology.inst_to_cosmo_vol(z), expected, rel_tol=1e-12)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,75 @@
+import ctypes
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
+
+from bayeseor.gpu import GPUInterface
+
+
+class FakeFunction:
+    def __init__(self) -> None:
+        self.argtypes: list[object] | None = None
+
+
+class FakeMagmaLibrary:
+    def __init__(self) -> None:
+        self.magma_init = FakeFunction()
+        self.magma_finalize = FakeFunction()
+        self.magma_zpotrf = FakeFunction()
+
+
+class FakeDevice:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+    @staticmethod
+    def count() -> int:
+        return 2
+
+    def name(self) -> str:
+        return f"Fake GPU {self.index}"
+
+
+def test_gpu_interface_falls_back_when_pycuda_is_unavailable(
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    sys.modules.pop("pycuda", None)
+    sys.modules.pop("pycuda.autoinit", None)
+    sys.modules.pop("pycuda.driver", None)
+
+    interface = GPUInterface(verbose=False)
+
+    assert not interface.gpu_initialized
+    captured = capsys.readouterr()
+    assert "Exception loading GPU encountered" in captured.out
+
+
+def test_gpu_interface_initializes_with_stubbed_cuda_dependencies(
+    monkeypatch: Any,
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    fake_pycuda = types.ModuleType("pycuda")
+    fake_autoinit = types.ModuleType("pycuda.autoinit")
+    fake_driver = types.ModuleType("pycuda.driver")
+    cast(Any, fake_driver).Device = FakeDevice
+    cast(Any, fake_pycuda).autoinit = fake_autoinit
+    cast(Any, fake_pycuda).driver = fake_driver
+
+    monkeypatch.setitem(sys.modules, "pycuda", fake_pycuda)
+    monkeypatch.setitem(sys.modules, "pycuda.autoinit", fake_autoinit)
+    monkeypatch.setitem(sys.modules, "pycuda.driver", fake_driver)
+    monkeypatch.setattr(ctypes, "CDLL", lambda _: FakeMagmaLibrary())
+
+    interface = GPUInterface(base_dir=tmp_path, rank=0, verbose=True)
+
+    assert interface.gpu_initialized
+    assert interface.base_dir == tmp_path
+    assert interface.magma_zpotrf.argtypes is not None
+
+    captured = capsys.readouterr()
+    assert "Loading shared library" in captured.out
+    assert "Computing on GPU(s)" in captured.out
+    assert "Rank 0: 2 GPUs (Fake GPU 0, Fake GPU 1)" in captured.out

--- a/tests/test_matrices_build.py
+++ b/tests/test_matrices_build.py
@@ -14,6 +14,43 @@ class FakeHealpix:
         self.pixel_area_sr = 0.25
 
 
+class FakeMatrixHealpix:
+    def __init__(self) -> None:
+        self.jds = np.array([2450000.0], dtype=float)
+        self.ra_eor = np.array([0.01, 0.02], dtype=float)
+        self.dec_eor = np.array([0.03, 0.04], dtype=float)
+        self.ra_fg = np.array([0.1, 0.2], dtype=float)
+        self.dec_fg = np.array([0.3, 0.4], dtype=float)
+        self.fovs_match = True
+        self.npix_fov = 2
+        self.eor_to_fg_pix = np.array([0, 1], dtype=int)
+
+    def calc_lmn_from_radec(
+        self,
+        time: float,
+        ra: np.ndarray[Any, Any],
+        dec: np.ndarray[Any, Any],
+        radec_offset: Any = None,
+        return_azza: bool = False,
+    ) -> tuple[np.ndarray[Any, Any], ...]:
+        ls = np.array([1.0, 2.0], dtype=float)
+        ms = np.array([3.0, 4.0], dtype=float)
+        ns = np.array([5.0, 6.0], dtype=float)
+        if return_azza:
+            az = np.array([0.7, 0.8], dtype=float)
+            za = np.array([0.9, 1.0], dtype=float)
+            return ls, ms, ns, az, za
+        return ls, ms, ns
+
+    def get_beam_vals(
+        self,
+        az: np.ndarray[Any, Any],
+        za: np.ndarray[Any, Any],
+        freq: float,
+    ) -> np.ndarray[Any, Any]:
+        return np.array([freq, freq + 1.0], dtype=float)
+
+
 def _base_build_kwargs() -> dict[str, Any]:
     return {
         "nu": 2,
@@ -98,3 +135,377 @@ def test_build_matrices_requires_uvw_array_when_instrumental_effects_enabled(
             dt=10.0,
             beam_type="uniform",
         )
+
+
+def test_build_taper_matrix_outputs_expected_diagonal() -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.taper_func = "boxcar"
+    bm.nf = 3
+    bm.nt = 2
+    bm.uvw_array_m = np.zeros((2, 2, 3), dtype=float)
+    bm.use_sparse_matrices = False
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    cast_bm = bm  # retain local name for readability
+    setattr(cast_bm, "output_data", fake_output_data)
+
+    build_module.BuildMatrices.build_taper_matrix(bm)
+
+    assert captured["name"] == "taper_matrix"
+    expected_taper = np.tile(
+        np.repeat(np.ones(3, dtype=float)[None, :], 2, axis=0).flatten(order="F"),
+        2,
+    )
+    np.testing.assert_allclose(np.diag(captured["matrix"]), expected_taper)
+
+
+def test_build_phasor_matrix_outputs_expected_diagonal() -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.phasor = np.array([1.0 + 0.0j, 0.0 + 1.0j], dtype=complex)
+    bm.use_sparse_matrices = False
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    build_module.BuildMatrices.build_phasor_matrix(bm)
+
+    assert captured["name"] == "phasor_matrix"
+    np.testing.assert_allclose(np.diag(captured["matrix"]), bm.phasor)
+
+
+def test_build_multi_chan_nudft_uses_scalar_time_center(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.uvw_array_m = np.zeros((1, 2, 3), dtype=float)
+    bm.freqs_hertz = np.array([100e6, 101e6], dtype=float)
+    bm.drift_scan = False
+    setattr(bm, "hpx", FakeMatrixHealpix())
+    bm.nt = 1
+    bm.nf = 2
+    bm.beam_center = None
+    bm.use_sparse_matrices = False
+    bm.Finv_normalisation = 0.25
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_nudft(
+        sampled_lmn_coords_radians: np.ndarray[Any, Any],
+        sampled_uvw_coords: np.ndarray[Any, Any],
+    ) -> np.ndarray[Any, Any]:
+        return np.full(
+            (sampled_uvw_coords.shape[0], sampled_lmn_coords_radians.shape[0]),
+            2.0,
+            dtype=float,
+        )
+
+    monkeypatch.setattr(build_module, "nuDFT_Array_DFT_2D_v2d0", fake_nudft)
+
+    build_module.BuildMatrices.build_multi_chan_nudft(bm)
+
+    assert captured["name"] == "multi_chan_nudft"
+    expected = np.block(
+        [
+            [np.full((2, 2), 0.5, dtype=float), np.zeros((2, 2), dtype=float)],
+            [np.zeros((2, 2), dtype=float), np.full((2, 2), 0.5, dtype=float)],
+        ]
+    )
+    np.testing.assert_allclose(captured["matrix"], expected)
+
+
+def test_build_multi_chan_beam_uses_scalar_time_center() -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.achromatic_beam = False
+    bm.freqs_hertz = np.array([100e6, 101e6], dtype=float)
+    bm.drift_scan = False
+    setattr(bm, "hpx", FakeMatrixHealpix())
+    bm.nt = 1
+    bm.beam_center = None
+    bm.use_sparse_matrices = False
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    build_module.BuildMatrices.build_multi_chan_beam(bm)
+
+    assert captured["name"] == "multi_chan_beam"
+    expected = np.diag([100e6, 100e6 + 1.0, 101e6, 101e6 + 1.0])
+    np.testing.assert_allclose(captured["matrix"], expected)
+
+
+def test_build_nuidft_array_uses_scalar_time_center(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    setattr(bm, "hpx", FakeMatrixHealpix())
+    bm.nt = 1
+    bm.nu = 2
+    bm.nv = 2
+    bm.du_eor = 0.1
+    bm.dv_eor = 0.2
+    bm.Fprime_normalization_eor = 0.5
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_nuidft_matrix_2d(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        return np.full((2, 3), 2.0, dtype=float)
+
+    monkeypatch.setattr(build_module, "nuidft_matrix_2d", fake_nuidft_matrix_2d)
+
+    build_module.BuildMatrices.build_nuidft_array(bm)
+
+    assert captured["name"] == "nuidft_array"
+    np.testing.assert_allclose(captured["matrix"], np.full((2, 3), 1.0))
+
+
+def test_build_multi_chan_nuidft_fg_preserves_monopole_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    setattr(bm, "hpx", FakeMatrixHealpix())
+    bm.nt = 1
+    bm.nf = 2
+    bm.nu_fg = 2
+    bm.nv_fg = 2
+    bm.du_fg = 0.1
+    bm.dv_fg = 0.2
+    bm.Fprime_normalization_fg = 0.5
+    bm.fit_for_monopole = True
+    bm.nuv_fg = 4
+    bm.use_sparse_matrices = False
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_nuidft_matrix_2d(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        return np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]], dtype=float)
+
+    monkeypatch.setattr(build_module, "nuidft_matrix_2d", fake_nuidft_matrix_2d)
+
+    build_module.BuildMatrices.build_multi_chan_nuidft_fg(bm)
+
+    assert captured["name"] == "multi_chan_nuidft_fg"
+    single_block = np.array([[0.5, 1.0, 2.0, 1.5], [5.0, 10.0, 20.0, 15.0]])
+    expected = np.block(
+        [
+            [single_block, np.zeros_like(single_block)],
+            [np.zeros_like(single_block), single_block],
+        ]
+    )
+    np.testing.assert_allclose(captured["matrix"], expected)
+
+
+def test_build_nuidft_array_sh_uses_eor_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    setattr(bm, "hpx", FakeMatrixHealpix())
+    bm.nt = 1
+    bm.nf = 2
+    bm.nu = 2
+    bm.nv = 2
+    bm.nu_sh = 1
+    bm.nv_sh = 1
+    bm.Fprime_normalization_eor = 0.5
+    bm.use_sparse_matrices = False
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_idft_array(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        return np.full((2, 1), 4.0, dtype=float)
+
+    monkeypatch.setattr(build_module, "IDFT_Array_IDFT_2D_ZM_SH", fake_idft_array)
+
+    build_module.BuildMatrices.build_nuidft_array_sh(bm)
+
+    assert captured["name"] == "nuidft_array_sh"
+    expected_block = np.full((2, 1), 0.5, dtype=float)
+    expected = np.block(
+        [
+            [expected_block, np.zeros_like(expected_block)],
+            [np.zeros_like(expected_block), expected_block],
+        ]
+    )
+    np.testing.assert_allclose(captured["matrix"], expected)
+
+
+def test_build_idft_array_1d_sh_uses_funcs_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.nf = 3
+    bm.neta = 2
+    bm.nq_sh = 1
+    bm.npl_sh = 0
+    bm.fit_for_shg_amps = False
+    bm.f_min = 100.0
+    bm.df = 1.0
+    bm.beta = None
+    bm.Fz_normalization = 0.5
+    bm.nu_sh = 2
+    bm.nv_sh = 2
+    bm.load_prerequisites = lambda matrix_name: {}
+    bm.use_sparse_matrices = False
+    captured: dict[str, Any] = {}
+    called: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_idft_array_idft_1d_sh(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        called["kwargs"] = kwargs
+        return np.full((3, 2), 2.0, dtype=float)
+
+    monkeypatch.setattr(build_module, "idft_array_idft_1d_sh", fake_idft_array_idft_1d_sh)
+
+    build_module.BuildMatrices.build_idft_array_1d_sh(bm)
+
+    assert called["kwargs"]["f_min"] == 100.0
+    assert called["kwargs"]["df"] == 1.0
+    assert captured["name"] == "idft_array_1d_sh"
+    expected_block = np.full((3, 2), 2.0 * 0.5 * 2, dtype=float)
+    expected = np.block(
+        [
+            [expected_block, np.zeros_like(expected_block), np.zeros_like(expected_block)],
+            [np.zeros_like(expected_block), expected_block, np.zeros_like(expected_block)],
+            [np.zeros_like(expected_block), np.zeros_like(expected_block), expected_block],
+        ]
+    )
+    np.testing.assert_allclose(captured["matrix"], expected)
+
+
+def test_build_idft_array_1d_fg_handles_monopole_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.nf = 3
+    bm.deta = 0.5
+    bm.neta = 2
+    bm.nuv_fg = 4
+    bm.fit_for_monopole = True
+    bm.nq = 1
+    bm.npl = 0
+    bm.f_min = 100.0
+    bm.df = 1.0
+    bm.beta = None
+    bm.use_sparse_matrices = False
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    def fake_build_lssm_basis_vectors(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        return np.array([[1.0], [2.0], [3.0]], dtype=complex)
+
+    def fake_idft_matrix_1d(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        return np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            dtype=complex,
+        )
+
+    monkeypatch.setattr(build_module, "build_lssm_basis_vectors", fake_build_lssm_basis_vectors)
+    monkeypatch.setattr(build_module, "idft_matrix_1d", fake_idft_matrix_1d)
+
+    build_module.BuildMatrices.build_idft_array_1d_fg(bm)
+
+    assert captured["name"] == "idft_array_1d_fg"
+    assert captured["matrix"].shape[0] > 0
+
+
+def test_build_ninv_without_instrumental_effects() -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.include_instrumental_effects = False
+    bm.nu = 2
+    bm.nv = 3
+    bm.nf = 2
+    bm.sigma = 4.0
+    bm.use_sparse_matrices = False
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    build_module.BuildMatrices.build_Ninv(bm)
+
+    assert captured["name"] == "Ninv"
+    np.testing.assert_allclose(np.diag(captured["matrix"]), np.full(10, 1.0 / 16.0))
+
+
+def test_build_n_without_instrumental_effects() -> None:
+    bm = object.__new__(build_module.BuildMatrices)
+    bm.verbose = False
+    bm.include_instrumental_effects = False
+    bm.nu = 2
+    bm.nv = 3
+    bm.nf = 2
+    bm.sigma = 4.0
+    bm.use_sparse_matrices = False
+    bm.load_prerequisites = lambda matrix_name: {}
+    captured: dict[str, Any] = {}
+
+    def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
+        captured["matrix"] = matrix
+        captured["name"] = name
+
+    setattr(bm, "output_data", fake_output_data)
+
+    build_module.BuildMatrices.build_N(bm)
+
+    assert captured["name"] == "N"
+    np.testing.assert_allclose(np.diag(captured["matrix"]), np.full(10, 16.0))

--- a/tests/test_matrices_build.py
+++ b/tests/test_matrices_build.py
@@ -106,7 +106,9 @@ def test_build_matrices_constructor_registers_optional_matrix_helpers(
     assert "taper_matrix" in bm.matrix_prereqs["Finv"]
 
 
-def test_build_matrices_constructor_without_instrumental_effects_skips_healpix() -> None:
+def test_build_matrices_constructor_without_instrumental_effects_skips_healpix() -> (
+    None
+):
     bm = build_module.BuildMatrices(
         **_base_build_kwargs(),
         include_instrumental_effects=False,
@@ -409,7 +411,9 @@ def test_build_idft_array_1d_sh_uses_funcs_signature(
         called["kwargs"] = kwargs
         return np.full((3, 2), 2.0, dtype=float)
 
-    monkeypatch.setattr(build_module, "idft_array_idft_1d_sh", fake_idft_array_idft_1d_sh)
+    monkeypatch.setattr(
+        build_module, "idft_array_idft_1d_sh", fake_idft_array_idft_1d_sh
+    )
 
     build_module.BuildMatrices.build_idft_array_1d_sh(bm)
 
@@ -419,9 +423,21 @@ def test_build_idft_array_1d_sh_uses_funcs_signature(
     expected_block = np.full((3, 2), 2.0 * 0.5 * 2, dtype=float)
     expected = np.block(
         [
-            [expected_block, np.zeros_like(expected_block), np.zeros_like(expected_block)],
-            [np.zeros_like(expected_block), expected_block, np.zeros_like(expected_block)],
-            [np.zeros_like(expected_block), np.zeros_like(expected_block), expected_block],
+            [
+                expected_block,
+                np.zeros_like(expected_block),
+                np.zeros_like(expected_block),
+            ],
+            [
+                np.zeros_like(expected_block),
+                expected_block,
+                np.zeros_like(expected_block),
+            ],
+            [
+                np.zeros_like(expected_block),
+                np.zeros_like(expected_block),
+                expected_block,
+            ],
         ]
     )
     np.testing.assert_allclose(captured["matrix"], expected)
@@ -451,7 +467,9 @@ def test_build_idft_array_1d_fg_handles_monopole_block(
 
     setattr(bm, "output_data", fake_output_data)
 
-    def fake_build_lssm_basis_vectors(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+    def fake_build_lssm_basis_vectors(
+        *args: Any, **kwargs: Any
+    ) -> np.ndarray[Any, Any]:
         return np.array([[1.0], [2.0], [3.0]], dtype=complex)
 
     def fake_idft_matrix_1d(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
@@ -460,7 +478,9 @@ def test_build_idft_array_1d_fg_handles_monopole_block(
             dtype=complex,
         )
 
-    monkeypatch.setattr(build_module, "build_lssm_basis_vectors", fake_build_lssm_basis_vectors)
+    monkeypatch.setattr(
+        build_module, "build_lssm_basis_vectors", fake_build_lssm_basis_vectors
+    )
     monkeypatch.setattr(build_module, "idft_matrix_1d", fake_idft_matrix_1d)
 
     build_module.BuildMatrices.build_idft_array_1d_fg(bm)

--- a/tests/test_matrices_build.py
+++ b/tests/test_matrices_build.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import bayeseor.matrices.build as build_module
+
+
+class FakeHealpix:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.pixel_area_sr = 0.25
+
+
+def _base_build_kwargs() -> dict[str, Any]:
+    return {
+        "nu": 2,
+        "du_eor": 0.1,
+        "nv": 2,
+        "dv_eor": 0.1,
+        "nu_fg": 2,
+        "du_fg": 0.2,
+        "nv_fg": 2,
+        "dv_fg": 0.2,
+        "nf": 3,
+        "neta": 2,
+        "deta": 1e-6,
+        "f_min": 100.0,
+        "df": 1.0,
+        "sigma": 1.5,
+    }
+
+
+def test_build_matrices_constructor_registers_optional_matrix_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(build_module, "Healpix", FakeHealpix)
+
+    bm = build_module.BuildMatrices(
+        **_base_build_kwargs(),
+        include_instrumental_effects=True,
+        uvw_array_m=np.zeros((2, 3, 3), dtype=float),
+        bl_red_array=np.ones((2, 3, 1), dtype=float),
+        nside=8,
+        fov_ra_eor=10.0,
+        fov_dec_eor=12.0,
+        jd_center=2450000.0,
+        nt=2,
+        dt=10.0,
+        beam_type="uniform",
+        phasor=np.ones(18, dtype=complex),
+        use_shg=True,
+        nu_sh=1,
+        nv_sh=1,
+        nq_sh=1,
+        npl_sh=1,
+        taper_func="hann",
+    )
+
+    np.testing.assert_allclose(bm.freqs_hertz, np.array([100e6, 101e6, 102e6]))
+    assert bm.Finv_normalisation == 0.25
+    assert "phasor_matrix" in bm.matrix_methods
+    assert "taper_matrix" in bm.matrix_methods
+    assert "idft_array_1d_sh" in bm.matrix_methods
+    assert "nuidft_array_sh" in bm.matrix_methods
+    assert "phasor_matrix" in bm.matrix_prereqs["Finv"]
+    assert "taper_matrix" in bm.matrix_prereqs["Finv"]
+
+
+def test_build_matrices_constructor_without_instrumental_effects_skips_healpix() -> None:
+    bm = build_module.BuildMatrices(
+        **_base_build_kwargs(),
+        include_instrumental_effects=False,
+    )
+
+    np.testing.assert_allclose(bm.freqs_hertz, np.array([100e6, 101e6, 102e6]))
+    assert bm.Finv_normalisation == 1.0
+    assert not hasattr(bm, "hpx")
+
+
+def test_build_matrices_requires_uvw_array_when_instrumental_effects_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(build_module, "Healpix", FakeHealpix)
+
+    with pytest.raises(AssertionError, match="uvw_array_m must not be None"):
+        build_module.BuildMatrices(
+            **_base_build_kwargs(),
+            include_instrumental_effects=True,
+            uvw_array_m=None,
+            bl_red_array=np.ones((2, 3, 1), dtype=float),
+            nside=8,
+            fov_ra_eor=10.0,
+            jd_center=2450000.0,
+            nt=2,
+            dt=10.0,
+            beam_type="uniform",
+        )

--- a/tests/test_matrices_build.py
+++ b/tests/test_matrices_build.py
@@ -343,10 +343,13 @@ def test_build_nuidft_array_sh_uses_eor_normalization(
     bm.nv = 2
     bm.nu_sh = 1
     bm.nv_sh = 1
+    bm.du_eor = 3.0
+    bm.dv_eor = 4.0
     bm.Fprime_normalization_eor = 0.5
     bm.use_sparse_matrices = False
     bm.load_prerequisites = lambda matrix_name: {}
     captured: dict[str, Any] = {}
+    called: dict[str, Any] = {}
 
     def fake_output_data(matrix: np.ndarray[Any, Any], name: str) -> None:
         captured["matrix"] = matrix
@@ -355,12 +358,15 @@ def test_build_nuidft_array_sh_uses_eor_normalization(
     setattr(bm, "output_data", fake_output_data)
 
     def fake_idft_array(*args: Any, **kwargs: Any) -> np.ndarray[Any, Any]:
+        called["kwargs"] = kwargs
         return np.full((2, 1), 4.0, dtype=float)
 
     monkeypatch.setattr(build_module, "IDFT_Array_IDFT_2D_ZM_SH", fake_idft_array)
 
     build_module.BuildMatrices.build_nuidft_array_sh(bm)
 
+    assert called["kwargs"]["delta_u_irad"] == 3.0
+    assert called["kwargs"]["delta_v_irad"] == 4.0
     assert captured["name"] == "nuidft_array_sh"
     expected_block = np.full((2, 1), 0.5, dtype=float)
     expected = np.block(

--- a/tests/test_matrices_funcs.py
+++ b/tests/test_matrices_funcs.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+
+from bayeseor.matrices.funcs import (
+    IDFT_Array_IDFT_2D_ZM_SH,
+    Produce_Coordinate_Arrays_ZM_SH,
+    build_lssm_basis_vectors,
+    idft_array_idft_1d_sh,
+)
+
+
+def test_idft_array_idft_2d_zm_sh_uses_explicit_linear_spacing() -> None:
+    sampled_lm_coords_radians = np.array([[0.0, 0.0], [0.25, -0.5]], dtype=float)
+    matrix = IDFT_Array_IDFT_2D_ZM_SH(
+        3,
+        3,
+        sampled_lm_coords_radians,
+        delta_u_irad=6.0,
+        delta_v_irad=3.0,
+    )
+
+    u_vec, v_vec = Produce_Coordinate_Arrays_ZM_SH(3, 3)
+    u_vec = u_vec.astype(float) * (6.0 / 3.0)
+    v_vec = v_vec.astype(float) * (3.0 / 3.0)
+    x_vec = sampled_lm_coords_radians[:, 0].reshape(-1, 1)
+    y_vec = sampled_lm_coords_radians[:, 1].reshape(-1, 1)
+    expected = np.exp(-2.0 * np.pi * 1j * (x_vec * u_vec + y_vec * v_vec))
+
+    np.testing.assert_allclose(matrix, expected)
+
+
+def test_build_lssm_basis_vectors_accepts_scalar_beta() -> None:
+    basis_vectors = build_lssm_basis_vectors(
+        nf=4, nq=1, npl=1, f_min=100.0, df=1.0, beta=2.63
+    )
+
+    freq_array = 100.0 + np.arange(4)
+    expected = (freq_array / 100.0) ** -2.63
+    np.testing.assert_allclose(basis_vectors[:, 0].real, expected)
+
+
+def test_build_lssm_basis_vectors_uses_distinct_power_law_indices() -> None:
+    basis_vectors = build_lssm_basis_vectors(
+        nf=3, nq=3, npl=3, f_min=100.0, df=1.0, beta=[1.0, 2.0, 3.0]
+    )
+
+    freq_array = 100.0 + np.arange(3)
+    expected = np.column_stack(
+        [
+            (freq_array / 100.0) ** -1.0,
+            (freq_array / 100.0) ** -2.0,
+            (freq_array / 100.0) ** -3.0,
+        ]
+    )
+    np.testing.assert_allclose(basis_vectors.real, expected)
+
+
+def test_idft_array_idft_1d_sh_uses_default_lssm_parameters() -> None:
+    idft_array = idft_array_idft_1d_sh(
+        nf=4, neta=3, nq_sh=1, npl_sh=0, fit_for_shg_amps=False
+    )
+
+    assert idft_array.shape == (4, 2)

--- a/tests/test_maxap.py
+++ b/tests/test_maxap.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from bayeseor.analyze.maxap import MaximumAPosteriori
+
+
+class FakePosterior:
+    def __init__(self) -> None:
+        self.T_Ninv_T = np.eye(2)
+        self.dbar = np.array([1.0, 2.0], dtype=float)
+        self.uprior_inds = np.array([True, False])
+
+    def calc_SigmaI_dbar_wrapper(
+        self,
+        dmps: np.ndarray[Any, Any],
+        T_Ninv_T: np.ndarray[Any, Any],
+        dbar: np.ndarray[Any, Any],
+    ) -> tuple[np.ndarray[Any, Any], float, np.ndarray[Any, Any], float]:
+        return (
+            np.array([0.5, 1.5], dtype=float),
+            4.0,
+            np.array([2.0, 8.0], dtype=float),
+            1.0,
+        )
+
+    def calc_PowerI(self, dmps: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+        return dmps * 2.0
+
+
+def _make_maxap() -> MaximumAPosteriori:
+    maxap = object.__new__(MaximumAPosteriori)
+    maxap.k_vals = np.array([0.1, 0.2], dtype=float)
+    maxap.pspp = FakePosterior()
+    maxap.T = np.eye(2)
+    return maxap
+
+
+def test_calculate_dmps_returns_array_for_scalar_ps() -> None:
+    maxap = _make_maxap()
+
+    dmps = maxap.calculate_dmps(ps=2.0)
+
+    assert isinstance(dmps, np.ndarray)
+    assert dmps.shape == maxap.k_vals.shape
+
+
+def test_map_estimate_handles_uniform_prior_indices() -> None:
+    maxap = _make_maxap()
+
+    map_coeffs, map_vis, log_post = maxap.map_estimate(dmps=np.array([3.0, 4.0]))
+
+    np.testing.assert_allclose(map_coeffs, np.array([0.5, 1.5]))
+    np.testing.assert_allclose(map_vis, np.array([0.5, 1.5]))
+    assert isinstance(log_post, float)
+
+
+def test_calculate_prior_covariance_uses_dmps_array() -> None:
+    maxap = _make_maxap()
+
+    prior_cov = maxap.calculate_prior_covariance(dmps=np.array([1.0, 2.0]))
+
+    np.testing.assert_allclose(prior_cov, np.array([2.0, 4.0]))

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+from bayeseor.model.noise import generate_gaussian_noise
+
+
+def test_generate_gaussian_noise_sigma_zero_returns_signal_and_zero_noise() -> None:
+    signal = np.array([1 + 2j, 3 + 4j])
+    uvw = np.array([[1.0, 0.0, 0.0], [-1.0, -0.0, 0.0]])
+    redundancy = np.ones((2, 1))
+
+    data, noise, conj_map = generate_gaussian_noise(
+        sigma=0.0,
+        s=signal,
+        nf=1,
+        nt=1,
+        uvw_array_meters=uvw,
+        bl_redundancy_array=redundancy,
+    )
+
+    np.testing.assert_array_equal(data, signal)
+    np.testing.assert_array_equal(noise, np.zeros_like(signal))
+    assert conj_map == {0: 1}
+
+
+def test_generate_gaussian_noise_is_deterministic_for_integer_seed() -> None:
+    signal = np.zeros(4, dtype=complex)
+    uvw = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, -0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [-2.0, -0.0, 0.0],
+        ]
+    )
+    redundancy = np.ones((4, 1))
+
+    result1 = generate_gaussian_noise(
+        sigma=2.0,
+        s=signal,
+        nf=1,
+        nt=1,
+        uvw_array_meters=uvw,
+        bl_redundancy_array=redundancy,
+        random_seed=7,
+    )
+    result2 = generate_gaussian_noise(
+        sigma=2.0,
+        s=signal,
+        nf=1,
+        nt=1,
+        uvw_array_meters=uvw,
+        bl_redundancy_array=redundancy,
+        random_seed=7,
+    )
+
+    np.testing.assert_allclose(result1[0], result2[0])
+    np.testing.assert_allclose(result1[1], result2[1])
+    assert result1[2] == result2[2]
+
+
+def test_generate_gaussian_noise_enforces_hermitian_pairs() -> None:
+    signal = np.zeros(2, dtype=complex)
+    uvw = np.array([[1.0, 0.0, 0.0], [-1.0, -0.0, 0.0]])
+    redundancy = np.ones((2, 1))
+
+    _, noise, conj_map = generate_gaussian_noise(
+        sigma=1.0,
+        s=signal,
+        nf=1,
+        nt=1,
+        uvw_array_meters=uvw,
+        bl_redundancy_array=redundancy,
+        random_seed=3,
+    )
+
+    assert conj_map == {0: 1}
+    assert np.allclose(noise[1], noise[0].conjugate())

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from bayeseor.posterior import PowerSpectrumPosteriorProbability, PriorC
+
+
+def _build_minimal_pspp(*, dimensionless_PS: bool = True) -> PowerSpectrumPosteriorProbability:
+    return PowerSpectrumPosteriorProbability(
+        T_Ninv_T=np.eye(2, dtype=complex),
+        dbar=np.zeros(2, dtype=complex),
+        k_vals=np.array([0.1]),
+        k_cube_voxels_in_bin=[np.array([0, 1])],
+        nuv=2,
+        neta=2,
+        nf=2,
+        nq=0,
+        Ninv=np.eye(2),
+        d_Ninv_d=np.array([1.0]),
+        redshift=8.0,
+        ps_box_size_ra_Mpc=1.0,
+        ps_box_size_dec_Mpc=1.0,
+        ps_box_size_para_Mpc=1.0,
+        use_gpu=False,
+        dimensionless_PS=dimensionless_PS,
+    )
+
+
+def test_priorc_maps_unit_cube_to_prior_ranges() -> None:
+    prior = PriorC([[1.0, 3.0], [10.0, 14.0]])
+
+    theta = prior.prior_func([0.25, 0.5])
+
+    assert theta == [1.5, 12.0]
+
+
+def test_calc_poweri_returns_expected_length_for_dimensionless_path() -> None:
+    pspp = _build_minimal_pspp()
+
+    power_i = pspp.calc_PowerI(np.array([2.0]))
+
+    assert power_i.shape == (2,)
+    expected_norm = pspp.calc_physical_dimensionless_power_spectral_normalisation(0)
+    assert np.allclose(power_i, expected_norm / 2.0)
+
+
+def test_calc_poweri_rejects_unimplemented_physical_pk_path() -> None:
+    pspp = _build_minimal_pspp(dimensionless_PS=False)
+
+    with pytest.raises(NotImplementedError, match="dimensionless_PS=True"):
+        pspp.calc_PowerI(np.array([1.0]))

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -4,7 +4,9 @@ import pytest
 from bayeseor.posterior import PowerSpectrumPosteriorProbability, PriorC
 
 
-def _build_minimal_pspp(*, dimensionless_PS: bool = True) -> PowerSpectrumPosteriorProbability:
+def _build_minimal_pspp(
+    *, dimensionless_PS: bool = True
+) -> PowerSpectrumPosteriorProbability:
     return PowerSpectrumPosteriorProbability(
         T_Ninv_T=np.eye(2, dtype=complex),
         dbar=np.zeros(2, dtype=complex),

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+import bayeseor.setup as bayes_setup
+
+
+class FakeBuildMatrices:
+    def __init__(self) -> None:
+        self.verbose = False
+        self.array_dir = "fake-array-dir"
+        self.freqs_hertz = np.array([150e6, 151e6], dtype=float)
+
+    def read_data(self, name: str) -> Any:
+        if name == "Ninv":
+            return np.eye(2)
+        if name == "T":
+            return np.eye(2, dtype=complex)
+        if name == "T_Ninv_T":
+            return np.eye(2)
+        if name == "block_T_Ninv_T":
+            return [np.eye(2)]
+        raise KeyError(name)
+
+    def dot_product(self, matrix: Any, vector: Any) -> Any:
+        return np.dot(matrix, vector)
+
+
+class FakePosterior:
+    def __init__(self) -> None:
+        self.k_vals = np.array([0.1, 0.2], dtype=float)
+
+
+def test_get_vis_data_preprocessed_path_builds_axes(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    data_path = tmp_path / "vis.npy"
+    noise_path = tmp_path / "noise.npy"
+    inst_model = tmp_path / "inst"
+    data_path.touch()
+    noise_path.touch()
+    inst_model.mkdir()
+    (inst_model / "uvw_model.npy").touch()
+    (inst_model / "redundancy_model.npy").touch()
+
+    vis = np.array([1 + 1j, 2 + 2j], dtype=complex)
+    noise = np.array([0.1 + 0.0j, 0.2 + 0.0j], dtype=complex)
+    uvws = np.zeros((2, 1, 3), dtype=float)
+    redundancy = np.ones((2, 1, 1), dtype=float)
+    antpairs = np.array([(0, 1)])
+    phasor = np.ones(2, dtype=complex)
+
+    def fake_load_numpy_dict(path: Path) -> np.ndarray[Any, Any]:
+        if path == data_path:
+            return vis
+        if path == noise_path:
+            return noise
+        raise AssertionError(f"Unexpected path {path}")
+
+    monkeypatch.setattr(bayes_setup, "load_numpy_dict", fake_load_numpy_dict)
+    monkeypatch.setattr(
+        bayes_setup,
+        "load_inst_model",
+        lambda _: (uvws, redundancy, antpairs, phasor),
+    )
+
+    vis_dict = bayes_setup.get_vis_data(
+        data_path=data_path,
+        nf=2,
+        df=1e6,
+        freq_min=150e6,
+        nt=2,
+        dt=10.0,
+        jd_min=2450000.0,
+        calc_noise=True,
+        noise_data_path=noise_path,
+        inst_model=inst_model,
+    )
+
+    np.testing.assert_allclose(vis_dict["vis_noisy"], vis)
+    np.testing.assert_allclose(vis_dict["noise"], noise)
+    np.testing.assert_allclose(vis_dict["freqs"], np.array([150e6, 151e6]))
+    np.testing.assert_allclose(
+        vis_dict["jds"],
+        np.array([2450000.0, 2450000.0 + 10.0 / 86400.0]),
+    )
+    np.testing.assert_array_equal(
+        vis_dict["bl_conj_pairs_map"], np.arange(vis.size, dtype=int)
+    )
+    assert "uvd" not in vis_dict
+
+
+def test_run_setup_return_vis_and_bm_preserves_tuple_contract(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    fake_vis_dict: bayes_setup.VisibilityData = {
+        "vis_noisy": np.array([1 + 0j, 2 + 0j], dtype=complex),
+        "noise": np.array([0.1 + 0j, 0.2 + 0j], dtype=complex),
+        "bl_conj_pairs_map": np.array([0, 1], dtype=int),
+        "uvws": np.zeros((1, 1, 3), dtype=float),
+        "redundancy": np.ones((1, 1, 1), dtype=float),
+        "freqs": np.array([150e6, 151e6], dtype=float),
+        "df": 1e6,
+        "jds": np.array([2450000.0, 2450000.1], dtype=float),
+        "dt": 10.0,
+        "vis": np.array([1 + 0j, 2 + 0j], dtype=complex),
+    }
+
+    fake_bm = FakeBuildMatrices()
+    fake_pspp = FakePosterior()
+
+    monkeypatch.setattr(bayes_setup, "get_vis_data", lambda **_: fake_vis_dict)
+    monkeypatch.setattr(
+        bayes_setup,
+        "build_k_cube",
+        lambda **_: (np.array([0.1, 0.2], dtype=float), [(np.array([0, 1]),)]),
+    )
+    monkeypatch.setattr(bayes_setup, "build_matrices", lambda **_: fake_bm)
+    monkeypatch.setattr(bayes_setup, "build_posterior", lambda **_: fake_pspp)
+    monkeypatch.setattr(
+        bayes_setup.Cosmology,
+        "f2z",
+        lambda self, freq: 8.0,
+    )
+    monkeypatch.setattr(
+        bayes_setup.Cosmology,
+        "dL_df",
+        lambda self, redshift: 1.0,
+    )
+    monkeypatch.setattr(
+        bayes_setup.Cosmology,
+        "dL_dth",
+        lambda self, redshift: 1.0,
+    )
+
+    result = bayes_setup.run_setup(
+        nu=2,
+        nside=1,
+        fov_ra_eor=10.0,
+        beam_type="uniform",
+        data_path=tmp_path / "vis.npy",
+        priors=[[0.0, 1.0]],
+        sigma=1.0,
+        include_instrumental_effects=False,
+        file_root_dir="run",
+        output_dir=tmp_path,
+        mkdir=False,
+        return_vis=True,
+        return_bm=True,
+    )
+
+    assert len(result) == 4
+    pspp, sampler_dir, vis_dict, bm = result
+    assert pspp is fake_pspp
+    assert sampler_dir == tmp_path / "run"
+    assert vis_dict is fake_vis_dict
+    assert bm is fake_bm

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,180 @@
+import json
+import importlib
+from pathlib import Path
+import sys
+import types
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from bayeseor import __version__
+
+
+class DummyParser:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, Path, str, bool]] = []
+
+    def save(
+        self,
+        args: object,
+        path: Path,
+        format: str,
+        skip_none: bool,
+    ) -> None:
+        self.calls.append((args, path, format, skip_none))
+        path.write_text(json.dumps({"saved": True}))
+
+
+class DummyComm:
+    def Get_rank(self) -> int:
+        return 0
+
+    def bcast(self, value: object, root: int = 0) -> object:
+        return value
+
+    def Barrier(self) -> None:
+        return None
+
+
+@pytest.fixture
+def utils_module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    fake_mpi4py = types.ModuleType("mpi4py")
+    cast(Any, fake_mpi4py).MPI = types.SimpleNamespace(
+        COMM_WORLD=DummyComm(),
+        Comm=DummyComm,
+    )
+
+    monkeypatch.setitem(sys.modules, "mpi4py", fake_mpi4py)
+    sys.modules.pop("bayeseor.utils", None)
+
+    return importlib.import_module("bayeseor.utils")
+
+
+def test_utils_import_does_not_require_mpi4py(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sys.modules.pop("bayeseor.utils", None)
+    monkeypatch.setitem(sys.modules, "mpi4py", None)
+
+    module = importlib.import_module("bayeseor.utils")
+
+    assert hasattr(module, "ShortTempPathManager")
+
+
+@pytest.mark.parametrize(
+    ("upriors_str", "nkbins", "expected"),
+    [
+        ("all", 4, np.array([True, True, True, True])),
+        ("", 4, np.array([False, False, False, False])),
+        ("1:3", 5, np.array([False, True, True, False, False])),
+        ("1,3", 5, np.array([False, True, False, True, False])),
+        ("-1", 4, np.array([False, False, False, True])),
+    ],
+)
+def test_parse_uprior_inds_variants(
+    utils_module: Any,
+    upriors_str: str,
+    nkbins: int,
+    expected: np.ndarray,
+) -> None:
+    result = utils_module.parse_uprior_inds(upriors_str, nkbins)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_write_log_files_writes_version_and_args_json(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    parser = DummyParser()
+    args = object()
+
+    utils_module.write_log_files(parser, args, out_dir=tmp_path)
+
+    assert (tmp_path / "version.txt").read_text().strip() == __version__
+    assert json.loads((tmp_path / "args.json").read_text()) == {"saved": True}
+    assert parser.calls == [(args, tmp_path / "args.json", "json", False)]
+
+
+def test_save_and_load_numpy_dict_round_trip(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    fp = tmp_path / "payload.npy"
+    arr = np.arange(4, dtype=float)
+    args = {"alpha": 1}
+
+    utils_module.save_numpy_dict(fp, arr, args, extra={"note": "ok"})
+    loaded = utils_module.load_numpy_dict(fp)
+
+    np.testing.assert_array_equal(loaded, arr)
+
+
+def test_save_numpy_dict_rejects_existing_file_without_clobber(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    fp = tmp_path / "payload.npy"
+    arr = np.arange(3)
+
+    utils_module.save_numpy_dict(fp, arr, {"alpha": 1})
+
+    with pytest.raises(ValueError, match="clobber is false"):
+        utils_module.save_numpy_dict(fp, arr, {"alpha": 1})
+
+
+def test_save_numpy_dict_requires_dict_extra(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    fp = tmp_path / "payload.npy"
+
+    with pytest.raises(ValueError, match="extra must be a dictionary"):
+        utils_module.save_numpy_dict(fp, np.arange(2), {"alpha": 1}, extra=["bad"])
+
+
+def test_vector_is_hermitian_detects_symmetric_pairs(utils_module: Any) -> None:
+    data = np.array([1 + 2j, 1 - 2j, 3 + 4j, 3 - 4j])
+    conj_map = {0: 1, 1: 0, 2: 3, 3: 2}
+
+    assert utils_module.vector_is_hermitian(data, conj_map, nt=1, nf=1, nbls=4)
+
+
+def test_vector_is_hermitian_detects_asymmetry(utils_module: Any) -> None:
+    data = np.array([1 + 2j, 1 - 1j])
+    conj_map = {0: 1, 1: 0}
+
+    assert not utils_module.vector_is_hermitian(data, conj_map, nt=1, nf=1, nbls=2)
+
+
+def test_short_temp_path_manager_creates_and_cleans_symlink(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "real-output"
+    output_dir.mkdir()
+    tmp_dir = tmp_path / "links"
+
+    manager = utils_module.ShortTempPathManager(
+        output_dir=output_dir,
+        tmp_dir=tmp_dir,
+        mpi_comm=DummyComm(),
+    )
+
+    assert manager.short_out_dir.is_symlink()
+    assert manager.short_out_dir.resolve() == output_dir.resolve()
+
+    manager.cleanup()
+
+    assert not manager.short_out_dir.exists()
+
+
+def test_short_temp_path_manager_requires_existing_output_dir(
+    utils_module: Any,
+    tmp_path: Path,
+) -> None:
+    missing_dir = tmp_path / "missing"
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        utils_module.ShortTempPathManager(missing_dir, mpi_comm=DummyComm())

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -346,7 +346,9 @@ def test_preprocess_uvdata_downselects_frequency_and_time(
 
     assert uvd is fake_uvd
     np.testing.assert_allclose(fake_uvd.freq_array, np.array([110e6, 120e6, 130e6]))
-    np.testing.assert_allclose(np.unique(fake_uvd.time_array), np.array([20.0, 30.0, 40.0]))
+    np.testing.assert_allclose(
+        np.unique(fake_uvd.time_array), np.array([20.0, 30.0, 40.0])
+    )
     assert len(antpairs) == 4
     assert uvws.shape == (3, 4, 3)
     assert redundancy.shape == (3, 4, 1)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from astropy import units
+from astropy.time import Time
+
+import bayeseor.vis as vis_module
+
+
+class FakeVectorUVData:
+    last_phase_time: Time | None = None
+
+    def __init__(
+        self,
+        antpairs: list[tuple[int, int]],
+        data_by_antpair: dict[tuple[int, int], np.ndarray[Any, Any]],
+        times: np.ndarray[Any, Any],
+    ) -> None:
+        self.antpairs = antpairs
+        self._antpair_index = {antpair: i for i, antpair in enumerate(antpairs)}
+        self.Nbls = len(antpairs)
+        self.Ntimes = len(times)
+        self.Nfreqs = next(iter(data_by_antpair.values())).shape[1]
+        self.Nblts = self.Nbls * self.Ntimes
+        self.Npols = 1
+        self.freq_array = np.arange(self.Nfreqs, dtype=float)
+        self.time_array = np.repeat(times, self.Nbls)
+        self.polarization_array = np.array([vis_module.polstr2num("xx")])
+        self.phase_calls: list[Time] = []
+        self._phasor_template = np.exp(
+            1j
+            * np.array(
+                [
+                    [0.0, np.pi / 4],
+                    [np.pi / 2, 3 * np.pi / 4],
+                    [np.pi, 5 * np.pi / 4],
+                ][: self.Ntimes]
+            )
+        )
+        self.data_array = np.zeros((self.Nblts, self.Nfreqs, 1), dtype=complex)
+        for antpair, vis in data_by_antpair.items():
+            self.data_array[self.antpair2ind(*antpair), :, 0] = vis
+
+    def copy(self) -> "FakeVectorUVData":
+        return deepcopy(self)
+
+    def antpair2ind(self, ant1: int, ant2: int) -> np.ndarray[Any, Any]:
+        i_bl = self._antpair_index[(ant1, ant2)]
+        return np.arange(i_bl, self.Nblts, self.Nbls)
+
+    def get_data(
+        self,
+        antpairpol: tuple[int, int, str],
+        force_copy: bool = False,
+    ) -> np.ndarray[Any, Any]:
+        ant1, ant2, _ = antpairpol
+        data = self.data_array[self.antpair2ind(ant1, ant2), :, 0]
+        if force_copy:
+            return data.copy()
+        return data
+
+    def phase_to_time(self, phase_time: Time) -> None:
+        self.phase_calls.append(phase_time)
+        type(self).last_phase_time = phase_time
+        for antpair in self.antpairs:
+            inds = self.antpair2ind(*antpair)
+            self.data_array[inds, :, 0] *= self._phasor_template
+
+
+class FakePIUVData:
+    def __init__(self) -> None:
+        self.polarization_array = np.array(
+            [vis_module.polstr2num("xx"), vis_module.polstr2num("yy")]
+        )
+        self.data_array = np.array([[[1.0 + 1.0j, 2.0 - 1.0j]]], dtype=complex)
+
+    def select(self, polarizations: list[str]) -> None:
+        if polarizations != ["xx"]:
+            raise AssertionError("Unexpected polarization selection")
+        xx_ind = np.where(self.polarization_array == vis_module.polstr2num("xx"))[0]
+        self.data_array = self.data_array[..., xx_ind]
+        self.polarization_array = self.polarization_array[xx_ind]
+
+
+class FakePreprocessUVData:
+    def __init__(self) -> None:
+        self.vis_units = "Jy"
+        self._antpairs = [(0, 1), (1, 2)]
+        self._times = np.array([10.0, 20.0, 30.0, 40.0], dtype=float)
+        self._freqs = np.array([100e6, 110e6, 120e6, 130e6], dtype=float)
+        self.polarization_array = np.array([vis_module.polstr2num("xx")])
+        self.Npols = 1
+        self.blt_order = ("time", "baseline")
+        self._unprojected = True
+        self._set_data_shapes()
+
+    def _set_data_shapes(self) -> None:
+        self.Nbls = len(self._antpairs)
+        self.Ntimes = len(self._times)
+        self.Nfreqs = len(self._freqs)
+        self.Nblts = self.Nbls * self.Ntimes
+        self.freq_array = self._freqs.copy()
+        self.time_array = np.repeat(self._times, self.Nbls)
+        self.data_array = np.ones((self.Nblts, self.Nfreqs, 1), dtype=complex)
+        self.flag_array = np.zeros((self.Nblts, self.Nfreqs, 1), dtype=bool)
+        self.uvw_array = np.tile(
+            np.array([[14.0, 0.0, 0.0], [28.0, 0.0, 0.0]], dtype=float),
+            (self.Ntimes, 1),
+        )
+
+    def read(
+        self,
+        fp: Path,
+        read_data: bool = True,
+        times: np.ndarray[Any, Any] | None = None,
+        frequencies: np.ndarray[Any, Any] | None = None,
+        bls: list[tuple[int, int]] | None = None,
+    ) -> None:
+        self.last_read = {
+            "fp": fp,
+            "read_data": read_data,
+            "times": None if times is None else np.asarray(times, dtype=float),
+            "frequencies": (
+                None if frequencies is None else np.asarray(frequencies, dtype=float)
+            ),
+            "bls": bls,
+        }
+        if times is not None:
+            self._times = np.asarray(times, dtype=float)
+        if frequencies is not None:
+            self._freqs = np.asarray(frequencies, dtype=float)
+        if bls is not None:
+            self._antpairs = list(bls)
+        self._set_data_shapes()
+
+    def select(
+        self,
+        ant_str: str | None = None,
+        blt_inds: np.ndarray[Any, Any] | None = None,
+        bls: list[tuple[int, int]] | None = None,
+        polarizations: list[str] | None = None,
+    ) -> None:
+        if bls is not None:
+            self._antpairs = list(bls)
+            self._set_data_shapes()
+        if polarizations is not None and polarizations != ["xx"]:
+            raise AssertionError("Unexpected polarization selection")
+
+    def get_antpairs(self) -> list[tuple[int, int]]:
+        return list(self._antpairs)
+
+    def get_flags(self, antpair: tuple[int, int]) -> np.ndarray[Any, Any]:
+        return np.zeros((self.Ntimes, self.Nfreqs), dtype=bool)
+
+    def _check_for_cat_type(self, cat_type: str) -> np.ndarray[Any, Any]:
+        return np.array([self._unprojected], dtype=bool)
+
+    def unproject_phase(self) -> None:
+        self._unprojected = True
+
+    def reorder_blts(self, order: str = "time") -> None:
+        self.blt_order = ("time", "baseline")
+
+    def antpair2ind(self, antpair: tuple[int, int]) -> np.ndarray[Any, Any]:
+        i_bl = self._antpairs.index(antpair)
+        return np.arange(i_bl, self.Nblts, self.Nbls)
+
+    def antnums_to_baseline(self, ant1: int, ant2: int) -> int:
+        return ant1 * 1000 + ant2
+
+
+def test_jy_to_ksr_preserves_shape_and_matches_quantity_conversion() -> None:
+    data = np.array([[1.0, 2.0], [3.0, 4.0]])
+    freqs = units.Quantity([150e6, 160e6], unit=units.Hz)
+
+    result = vis_module.jy_to_ksr(data, freqs)
+
+    equiv = units.brightness_temperature(freqs, beam_area=1 * units.sr)
+    conv_factor = np.asarray(
+        units.Quantity(1.0, unit=units.Jy).to_value(units.K, equivalencies=equiv),
+        dtype=float,
+    )
+    expected = data * conv_factor[np.newaxis, :]
+    np.testing.assert_allclose(result, expected)
+    assert result.shape == data.shape
+
+
+def test_form_pI_vis_combines_xx_and_yy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vis_module, "UVData", FakePIUVData)
+    uvd = FakePIUVData()
+
+    result = vis_module.form_pI_vis(uvd, norm=0.5)
+
+    np.testing.assert_allclose(result.data_array[..., 0], np.array([[1.5 + 0.0j]]))
+    np.testing.assert_array_equal(
+        result.polarization_array, np.array([vis_module.polstr2num("pI")])
+    )
+
+
+def test_uvd_to_vector_preserves_vector_ordering() -> None:
+    antpairs = [(0, 1), (1, 2)]
+    uvd = FakeVectorUVData(
+        antpairs=antpairs,
+        data_by_antpair={
+            (0, 1): np.array([[1.0, 2.0], [3.0, 4.0]], dtype=complex),
+            (1, 2): np.array([[10.0, 20.0], [30.0, 40.0]], dtype=complex),
+        },
+        times=np.array([1.0, 2.0]),
+    )
+
+    vis_vec, phasor_vec, noise_vec = vis_module.uvd_to_vector(uvd, antpairs)
+
+    assert vis_vec is not None
+    expected = np.array(
+        [
+            1.0,
+            10.0,
+            1.0,
+            10.0,
+            2.0,
+            20.0,
+            2.0,
+            20.0,
+            3.0,
+            30.0,
+            3.0,
+            30.0,
+            4.0,
+            40.0,
+            4.0,
+            40.0,
+        ],
+        dtype=complex,
+    )
+    np.testing.assert_allclose(vis_vec, expected)
+    assert phasor_vec is None
+    assert noise_vec is None
+
+
+def test_uvd_to_vector_noise_differencing() -> None:
+    antpairs = [(0, 1)]
+    uvd = FakeVectorUVData(
+        antpairs=antpairs,
+        data_by_antpair={
+            (0, 1): np.array([[1.0, 2.0], [5.0, 7.0], [9.0, 10.0]], dtype=complex)
+        },
+        times=np.array([1.0, 2.0, 3.0]),
+    )
+
+    _, _, noise_vec = vis_module.uvd_to_vector(uvd, antpairs, calc_noise=True)
+
+    assert noise_vec is not None
+    expected_noise = np.array(
+        [
+            -4.0,
+            -4.0,
+            -5.0,
+            -5.0,
+            -4.0,
+            -4.0,
+            -5.0,
+            -5.0,
+            4.0,
+            4.0,
+            3.0,
+            3.0,
+        ],
+        dtype=complex,
+    )
+    np.testing.assert_allclose(noise_vec, expected_noise)
+
+
+def test_uvd_to_vector_uses_central_time_when_phase_time_is_none() -> None:
+    antpairs = [(0, 1)]
+    FakeVectorUVData.last_phase_time = None
+    uvd = FakeVectorUVData(
+        antpairs=antpairs,
+        data_by_antpair={
+            (0, 1): np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=complex)
+        },
+        times=np.array([10.0, 20.0, 30.0]),
+    )
+
+    _, phasor_vec, _ = vis_module.uvd_to_vector(uvd, antpairs, phase=True)
+
+    assert phasor_vec is not None
+    assert uvd.phase_calls == []
+    assert FakeVectorUVData.last_phase_time is not None
+    assert FakeVectorUVData.last_phase_time.jd == Time(20.0, format="jd").jd
+    expected_phasor = np.array(
+        [
+            1.0 + 0.0j,
+            1.0 - 0.0j,
+            np.exp(1j * np.pi / 4),
+            np.exp(-1j * np.pi / 4),
+            1j,
+            -1j,
+            np.exp(1j * 3 * np.pi / 4),
+            np.exp(-1j * 3 * np.pi / 4),
+            -1.0 + 0.0j,
+            -1.0 - 0.0j,
+            np.exp(1j * 5 * np.pi / 4),
+            np.exp(-1j * 5 * np.pi / 4),
+        ],
+        dtype=complex,
+    )
+    np.testing.assert_allclose(phasor_vec, expected_phasor)
+
+
+def test_preprocess_uvdata_downselects_frequency_and_time(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_uvd = FakePreprocessUVData()
+    monkeypatch.setattr(vis_module, "UVData", lambda: fake_uvd)
+    monkeypatch.setattr(vis_module, "jy_to_ksr", lambda data, freqs, mK=True: data)
+
+    def fake_uvd_to_vector(
+        uvd: FakePreprocessUVData,
+        antpairs: list[tuple[int, int]],
+        **_: Any,
+    ) -> tuple[np.ndarray[Any, Any], None, None]:
+        n_vis = 2 * len(antpairs) * uvd.Ntimes * uvd.Nfreqs
+        return np.arange(n_vis, dtype=complex), None, None
+
+    monkeypatch.setattr(vis_module, "uvd_to_vector", fake_uvd_to_vector)
+
+    fp = tmp_path / "fake.uvh5"
+    fp.touch()
+
+    vis, antpairs, uvws, redundancy, phasor, noise, uvd = vis_module.preprocess_uvdata(
+        fp,
+        form_pI=False,
+        pol="xx",
+        freq_center=120e6,
+        Nfreqs=3,
+        jd_center=30.0,
+        Ntimes=3,
+        return_uvd=True,
+    )
+
+    assert uvd is fake_uvd
+    np.testing.assert_allclose(fake_uvd.freq_array, np.array([110e6, 120e6, 130e6]))
+    np.testing.assert_allclose(np.unique(fake_uvd.time_array), np.array([20.0, 30.0, 40.0]))
+    assert len(antpairs) == 4
+    assert uvws.shape == (3, 4, 3)
+    assert redundancy.shape == (3, 4, 1)
+    assert vis.shape == (36,)
+    assert phasor is None
+    assert noise is None
+
+
+def test_generate_mock_eor_signal_instrumental_uses_current_healpix_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    class FakeHealpix:
+        def __init__(self, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            self.npix_fov = 3
+
+    monkeypatch.setattr(vis_module, "Healpix", FakeHealpix)
+
+    signal, white_noise_sky = vis_module.generate_mock_eor_signal_instrumental(
+        Finv=np.eye(6, dtype=complex),
+        nf=2,
+        fov_ra_deg=10.0,
+        fov_dec_deg=12.0,
+        nside=8,
+        telescope_latlonalt=(1.0, 2.0, 3.0),
+        central_jd=2450000.0,
+        nt=1,
+        int_time=11.0,
+        random_seed=7,
+    )
+
+    assert captured_kwargs["fov_ra_eor"] == 10.0
+    assert captured_kwargs["fov_dec_eor"] == 12.0
+    assert captured_kwargs["jd_center"] == 2450000.0
+    assert captured_kwargs["dt"] == 11.0
+    assert white_noise_sky.shape == (2, 3)
+    assert signal.shape == (6,)


### PR DESCRIPTION
## Summary

This draft PR adds targeted test coverage and conservative typing cleanup across the BayesEoR package, with the goal of making the codebase safer to evolve and easier to validate under Python 3.12.

The work follows a test-first, module-by-module approach:
- add focused regression tests
- fix Pyright issues with minimal behavioral change
- preserve runtime behavior unless a warning reveals a real bug

## What changed

This PR now covers targeted cleanup and tests for:

- `bayeseor/model/healpix.py`
- `bayeseor/utils.py`
- `bayeseor/cosmology.py`
- `bayeseor/model/noise.py`
- `bayeseor/gpu.py`
- `bayeseor/posterior.py`
- `bayeseor/analyze/analyze.py`
- `bayeseor/vis.py`
- `bayeseor/setup.py`
- `bayeseor/analyze/maxap.py`
- `bayeseor/matrices/build.py`
- `bayeseor/matrices/funcs.py`
- `bayeseor/params.py`
- `bayeseor/model/__init__.py`

It also adds or extends pytest coverage in:

- `tests/test_healpix.py`
- `tests/test_model_init.py`
- `tests/test_utils.py`
- `tests/test_cosmology.py`
- `tests/test_noise.py`
- `tests/test_gpu.py`
- `tests/test_posterior.py`
- `tests/test_analyze.py`
- `tests/test_vis.py`
- `tests/test_setup.py`
- `tests/test_maxap.py`
- `tests/test_matrices_build.py`
- `tests/test_matrices_funcs.py`

## Notable fixes found during the cleanup

This work was not just editor noise reduction. The test-first pass exposed and fixed several real issues, including:

- `generate_gaussian_noise(..., sigma=0.0)` used `nbls` before assignment
- `uvd_to_vector` used `False` instead of `None` as the default `phase_time`, which did not match the documented behavior
- `ShortTempPathManager` and related utilities imported MPI too eagerly for non-MPI use cases
- the unsupported `dimensionless_PS=False` path in `posterior.py` failed via a latent missing-method error and is now made explicit
- subharmonic-grid helper code in `bayeseor/matrices/funcs.py` referenced a nonexistent global (`p`)
- `idft_array_idft_1d_sh` stacked the LSSM block with the wrong orientation
- `build_lssm_basis_vectors` had indexing/assignment issues in some higher-order power-law cases

## Status

Draft, but now fully validated for the current Python 3.12 baseline.

This branch now passes:
- the full pytest suite
- a full workspace Pyright run
- touched-file Ruff checks

## Validation

Validated in a Python 3.12 environment with:

```bash
python -m pytest tests
pyright
ruff check bayeseor/model/healpix.py bayeseor/utils.py bayeseor/cosmology.py bayeseor/model/noise.py bayeseor/gpu.py bayeseor/posterior.py bayeseor/analyze/analyze.py bayeseor/vis.py bayeseor/setup.py bayeseor/analyze/maxap.py bayeseor/matrices/build.py bayeseor/matrices/funcs.py bayeseor/params.py bayeseor/model/__init__.py tests
```

Current results:
- `65 passed`
- `pyright`: `0 errors, 0 warnings`
- `ruff`: clean for touched files and tests

## Notes

The intent of this PR is still conservative hardening rather than feature development:
- tests were added before or alongside typing fixes
- changes were kept narrow wherever possible
- third-party typing gaps were handled at API boundaries rather than by broad refactors
