### PR TITLE
Align environment and packaging with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install package and test dependencies

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,5 @@
-name: bayeseor
+# name: bayeseor
+name: bayeseor2
 channels:
   - conda-forge
 dependencies:
@@ -11,12 +12,12 @@ dependencies:
   - magma
   - matplotlib
   - mpi4py>=3.0.0
-  - numpy==2.2.6
+  - numpy>=1.26,<2
   - pip
   - pycuda
   - pymultinest
   - pytest
-  - python==3.13
+  - python==3.12
   - pyuvdata
   - rich
   - ruff

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,5 +1,4 @@
-# name: bayeseor
-name: bayeseor2
+name: bayeseor
 channels:
   - conda-forge
 dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-# requires-python = ">= 3.10"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.10,<3.13"
 
 dependencies = [
     "astropy",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,6 +8,6 @@
     "docs",
     "test_data"
   ],
-  "pythonVersion": "3.13",
+  "pythonVersion": "3.12",
   "typeCheckingMode": "basic"
 }


### PR DESCRIPTION
## Summary
This PR fixes the repository's environment and packaging constraints so the BayesEoR conda environment resolves cleanly again.

## Changes
- set the conda environment to `python==3.12`
- relax the NumPy pin to `numpy>=1.26,<2`
- align `pyproject.toml` with the updated python version
- update `pyrightconfig.json` and CI to target Python 3.12 for consistency

## Why
The previous combination of `python==3.13` and `numpy==2.2.6` was not solvable with the current conda-forge builds required by this project, notably in the `astropy-healpix` / `pyuvdata` / `pycuda` stack. It also conflicted with editable installation because `pyproject.toml` required Python 3.13 while the scientific dependency stack still resolves around older ABIs.

## Verification
- `mamba env create -f environment.yaml --dry-run`
  - solved successfully with Python 3.12.13 and NumPy 1.26.4 in the resolved environment


